### PR TITLE
테스트 서버용 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+/src/main/resources/application-private-stage.properties

--- a/HELP.md
+++ b/HELP.md
@@ -7,7 +7,7 @@ For further reference, please consider the following sections:
 * [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/docs/2.6.10/gradle-plugin/reference/html/)
 * [Create an OCI image](https://docs.spring.io/spring-boot/docs/2.6.10/gradle-plugin/reference/html/#build-image)
 * [Spring Web](https://docs.spring.io/spring-boot/docs/2.6.10/reference/htmlsingle/#web)
-* [Spring Data JPA](https://docs.spring.io/spring-boot/docs/2.6.10/reference/htmlsingle/#data.sql.jpa-and-spring-data)
+* [Spring Data JPA](https://docs.spring.io/spring-boot/docs/2.6.10/reference/htmlsingle/#data-h2.sql.jpa-and-spring-data)
 * [Validation](https://docs.spring.io/spring-boot/docs/2.6.10/reference/htmlsingle/#io.validation)
 * [Thymeleaf](https://docs.spring.io/spring-boot/docs/2.6.10/reference/htmlsingle/#web.servlet.spring-mvc.template-engines)
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'mysql:mysql-connector-java'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
+
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/heylocal/traveler/domain/chat/ChatMessage.java
+++ b/src/main/java/com/heylocal/traveler/domain/chat/ChatMessage.java
@@ -39,5 +39,5 @@ public class ChatMessage extends BaseTimeEntity {
 
   @Column(nullable = false)
   @ColumnDefault("false")
-  private Boolean read;
+  private Boolean readMessage;
 }

--- a/src/main/java/com/heylocal/traveler/domain/order/OrderSheet.java
+++ b/src/main/java/com/heylocal/traveler/domain/order/OrderSheet.java
@@ -8,7 +8,6 @@ import com.heylocal.traveler.domain.order.list.HopeTheme;
 import com.heylocal.traveler.domain.order.list.TravelMember;
 import com.heylocal.traveler.domain.travel.Travel;
 import com.heylocal.traveler.domain.user.Traveler;
-import com.heylocal.traveler.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/heylocal/traveler/domain/travel/list/PlaceItem.java
+++ b/src/main/java/com/heylocal/traveler/domain/travel/list/PlaceItem.java
@@ -36,7 +36,7 @@ public class PlaceItem extends BaseTimeEntity {
   private Place place;
 
   @Column(nullable = false)
-  private Integer order; //오름차순
+  private Integer itemIndex; //오름차순
 
   private Long originalPlaceId; // 현재 대체장소일때, 원장소의 id
 }

--- a/src/main/java/com/heylocal/traveler/util/UpperCaseNamingStrategy.java
+++ b/src/main/java/com/heylocal/traveler/util/UpperCaseNamingStrategy.java
@@ -1,0 +1,14 @@
+package com.heylocal.traveler.util;
+
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+import java.util.Locale;
+
+public class UpperCaseNamingStrategy extends CamelCaseToUnderscoresNamingStrategy {
+  @Override
+  protected Identifier getIdentifier(String name, boolean quoted, JdbcEnvironment jdbcEnvironment) {
+    return new Identifier(name.toUpperCase(Locale.ROOT), quoted );
+  }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,3 +1,6 @@
+# ?? ?? ?? ??
+spring.config.activate.on-profile=local
+
 # JPA
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create
@@ -5,11 +8,13 @@ spring.jpa.generate-ddl=true
 spring.jpa.database=h2
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.hibernate.naming.physical-strategy=com.heylocal.traveler.util.UpperCaseNamingStrategy
 
-# ?? dml ??
+# DML - data-h2.sql
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 spring.sql.init.encoding=UTF-8
+spring.sql.init.data-locations=classpath:data-h2.sql
 
 
 # H2

--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -1,0 +1,22 @@
+
+
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://hey-local-test.ccz7k3aczohz.ap-northeast-2.rds.amazonaws.com:3306/hey_local?serverTimezone=UTC&characterEncoding=UTF-8
+spring.jpa.show-sql=true
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect
+spring.jpa.properties.hibernate.dialect.storage_engine=innodb
+spring.session.store-type=jdbc
+spring.jpa.hibernate.use-new-id-generator-mappings=false
+spring.jpa.hibernate.naming.physical-strategy=com.heylocal.traveler.util.UpperCaseNamingStrategy
+
+# Hibernate ??
+logging.level.org.hibernate=info
+
+# DML - data-mariadb.sql
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
+spring.sql.init.encoding=UTF-8
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+# active profile configuration
+spring.profiles.active=local
+#spring.profiles.active=stage
+spring.profiles.group.stage=private-stage

--- a/src/main/resources/data-h2.sql
+++ b/src/main/resources/data-h2.sql
@@ -1,0 +1,3 @@
+/* 매니저 INSERT */
+insert into "USER"("ID", "ACCOUNT_ID", "PASSWORD", "PHONE_NUMBER", "USER_TYPE", "DTYPE") values (0, 'admin', 'admin123', '010-1234-1234', 'SERVICE_MANAGER', 'SERVICE_MANAGER');
+insert into "SERVICE_MANAGER"("ID", "NICKNAME") values (0, 'admin');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,0 @@
-/* 매니저 INSERT */
-insert into "user"("id", "account_id", "password", "phone_number", "user_type", "dtype") values (0, 'admin', 'admin123', '010-1234-1234', 'SERVICE_MANAGER', 'SERVICE_MANAGER');
-insert into "service_manager"("id", "nickname") values (0, 'admin');


### PR DESCRIPTION
## Changes
- JPA `ddl-auto` 의 네이밍 전략을 추가하여, 적용함.
  - 오직 대문자 + 언더바
- AWS 에 테스트용(Stage)으로 생성한 MariaDB 와 통신할 수 있도록 properties 파일을 추가함.
  - DBMS 접근 계정 정보는 따로 `.properties` 파일에 작성하고,  .gitignore 에 추가함.
- 아래 오류를 수정함.
  - `MariaDB 에서 사용하는 예약어` 를 칼럼명으로 가지고 있어, `ddl-auto` 시 오류가 발생함.
