### PR TITLE
Fix: Maria DB 접근 url 수정

### DIFF
--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -2,7 +2,7 @@
 spring.config.activate.on-profile=private-stage
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://hey-local-test.ccz7k3aczohz.ap-northeast-2.rds.amazonaws.com:3306/hey_local?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://hey-local-test.ccz7k3aczohz.ap-northeast-2.rds.amazonaws.com:3306/hey_local?serverTimezone=UTC&characterEncoding=UTF-8&useSSL=false
 spring.jpa.show-sql=true
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
- 배포시 EC2가 root 계정으로 접근하는 문제를 해결하기 위함.
- application-private-stage.properties 파일을 사용해서 DB에 접근해야한다.