### PR TITLE
Fix: DML 관련 properties 삭제

### DIFF
--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -16,8 +16,3 @@ spring.jpa.hibernate.naming.physical-strategy=com.heylocal.traveler.util.UpperCa
 # Hibernate ??
 logging.level.org.hibernate=info
 
-# DML - data-mariadb.sql
-spring.jpa.defer-datasource-initialization=true
-spring.sql.init.mode=always
-spring.sql.init.encoding=UTF-8
-


### PR DESCRIPTION
- 배포시 EC2가 root 계정으로 접근하는 문제를 해결하기 위함.
- application-private-stage.properties 파일을 사용해서 DB에 접근해야한다.
- 필요없는 properties를 삭제함