### PR TITLE
Fix: MariaDB Connector 의존성 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'mysql:mysql-connector-java'
+	implementation("org.mariadb.jdbc:mariadb-java-client")
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -1,7 +1,7 @@
 # with private-stage
 spring.config.activate.on-profile=private-stage
 
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.url=jdbc:mysql://hey-local-test.ccz7k3aczohz.ap-northeast-2.rds.amazonaws.com:3306/hey_local?serverTimezone=UTC&characterEncoding=UTF-8
 spring.jpa.show-sql=true
 spring.jpa.generate-ddl=true


### PR DESCRIPTION
- 배포시 EC2가 root 계정으로 접근하는 문제를 해결하기 위함.
- application-private-stage.properties 파일을 사용해서 DB에 접근해야한다.
- MySQL Connector 대신 MariaDB로 지정함.