### PR TITLE
[S3T-331] spring.mvc.pathmatch.matching-strategy 속성 설정 파일 변경

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,6 +1,3 @@
-# ?? ?? ?? ??
-spring.config.activate.on-profile=local
-
 # JPA
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create
@@ -31,5 +28,3 @@ spring.jpa.properties.hibernate.globally_quoted_identifiers=true
 # Hibernate ??
 logging.level.org.hibernate=info
 
-# Swagger
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -16,6 +16,3 @@ spring.jpa.hibernate.naming.physical-strategy=com.heylocal.traveler.util.UpperCa
 # Hibernate ??
 logging.level.org.hibernate=info
 
-# Swagger
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher
-

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 # active profile configuration
 #spring.profiles.active=local
 #spring.profiles.active=stage
+
+# Swagger
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher


### PR DESCRIPTION
- 빌드 시, test가 실패하는 문제를 해결함.
- spring.mvc.pathmatch.matching-strategy 설정을 local.properties 와 stage.properties 에서만 작성함.
- 따라서, App 구동 test가 실패함.
- application.properties 파일에서 spring.mvc.pathmatch.matching-strategy 값을 설정하여, 공통적으로 사용하도록 수정함.