### PR TITLE
[S3T-434] 여행On 삭제 API 500 에러 수정

### DIFF
--- a/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
+++ b/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
@@ -12,6 +12,7 @@ import lombok.experimental.SuperBuilder;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * 여행
@@ -28,7 +29,7 @@ public class Plan extends BaseTimeEntity {
   @GeneratedValue
   private Long id;
 
-  @OneToOne(optional = false, fetch = FetchType.LAZY)
+  @OneToOne(fetch = FetchType.LAZY)
   private TravelOn travelOn;
 
   @ManyToOne(optional = false)
@@ -39,4 +40,13 @@ public class Plan extends BaseTimeEntity {
   @Builder.Default
   @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private List<DaySchedule> dayScheduleList = new ArrayList<>();
+
+  public void releaseTravelOn() {
+    TravelOn temp = this.travelOn;
+    this.travelOn = null;
+
+    if (!Objects.isNull(temp)) {
+      temp.releasePlan();
+    }
+  }
 }

--- a/src/main/java/com/heylocal/traveler/domain/travelon/TravelOn.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/TravelOn.java
@@ -18,10 +18,7 @@ import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * 여행 On
@@ -197,5 +194,13 @@ public class TravelOn extends BaseTimeEntity {
 
   public void removeAllTravelMember() {
     this.travelMemberSet.clear();
+  }
+  public void releasePlan() {
+    Plan temp = this.plan;
+    this.plan = null;
+
+    if (!Objects.isNull(temp)) {
+      temp.releaseTravelOn();
+    }
   }
 }

--- a/src/main/java/com/heylocal/traveler/service/TravelOnService.java
+++ b/src/main/java/com/heylocal/traveler/service/TravelOnService.java
@@ -171,6 +171,9 @@ public class TravelOnService {
       throw new ForbiddenException(ForbiddenCode.NO_PERMISSION, "답변이 달린 여행On 은 삭제할 수 없습니다.");
     }
 
+    //연관된 Plan 엔티티 해제
+    target.releasePlan();
+
     //여행 On 삭제
     travelOnRepository.remove(target);
   }


### PR DESCRIPTION
## Bug Fix
- Bug 원인
  - 여행On(`TravelOn`)과 여행계획(`Plan`)이 서로 1대1 관계를 맺고, 여행계획의 외래키 칼럼 `TRAVEL_ON_ID` 가 null 을 허용하지 않은 것이 원인임
- 따라서 `TRAVEL_ON_ID` 칼럼에 null 을 허용하고, 여행On 을 제거하기 전에 null 로 설정하도록 수정함.