### PR TITLE
[S3T-498] MapStruct 를 사용하여 `Entity` <-> `DTO` 간 매핑 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,16 @@ dependencies {
 	implementation("org.mariadb.jdbc:mariadb-java-client")
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'org.mapstruct:mapstruct:1.5.2.Final'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.2.Final'
 
 	testAnnotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.2.Final'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.jsonwebtoken:jjwt:0.9.1'
 

--- a/src/main/java/com/heylocal/traveler/domain/Region.java
+++ b/src/main/java/com/heylocal/traveler/domain/Region.java
@@ -3,10 +3,7 @@ package com.heylocal.traveler.domain;
 import com.heylocal.traveler.domain.place.Place;
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.travelon.opinion.Opinion;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -21,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @Builder
 public class Region {
   @Id @GeneratedValue
@@ -49,7 +47,7 @@ public class Region {
   public void addOpinion(Opinion opinion) {
     this.getOpinionList().add(opinion);
     if (opinion.getRegion() != this) {
-      opinion.registerRegion(this);
+      opinion.setRegion(this);
     }
   }
 

--- a/src/main/java/com/heylocal/traveler/domain/article/Article.java
+++ b/src/main/java/com/heylocal/traveler/domain/article/Article.java
@@ -4,6 +4,7 @@ import com.heylocal.traveler.domain.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -16,6 +17,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class Article extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/article/ArticleImageContent.java
+++ b/src/main/java/com/heylocal/traveler/domain/article/ArticleImageContent.java
@@ -4,6 +4,7 @@ import com.heylocal.traveler.domain.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -16,6 +17,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class ArticleImageContent extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/chat/ChatMessage.java
+++ b/src/main/java/com/heylocal/traveler/domain/chat/ChatMessage.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -19,6 +20,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class ChatMessage extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/chat/ChatRoom.java
+++ b/src/main/java/com/heylocal/traveler/domain/chat/ChatRoom.java
@@ -2,10 +2,7 @@ package com.heylocal.traveler.domain.chat;
 
 import com.heylocal.traveler.domain.BaseTimeEntity;
 import com.heylocal.traveler.domain.user.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -20,6 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class ChatRoom extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/notification/Notification.java
+++ b/src/main/java/com/heylocal/traveler/domain/notification/Notification.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -17,6 +18,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class Notification extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/place/Place.java
+++ b/src/main/java/com/heylocal/traveler/domain/place/Place.java
@@ -20,6 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class Place extends BaseTimeEntity {
   @Id
@@ -65,7 +66,7 @@ public class Place extends BaseTimeEntity {
   public void addOpinion(Opinion opinion) {
     this.opinionList.add(opinion);
     if (opinion.getPlace() != this) {
-      opinion.registerPlace(this);
+      opinion.setPlace(this);
     }
   }
 

--- a/src/main/java/com/heylocal/traveler/domain/plan/DaySchedule.java
+++ b/src/main/java/com/heylocal/traveler/domain/plan/DaySchedule.java
@@ -2,10 +2,7 @@ package com.heylocal.traveler.domain.plan;
 
 import com.heylocal.traveler.domain.BaseTimeEntity;
 import com.heylocal.traveler.domain.plan.list.PlaceItem;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -21,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class DaySchedule extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
+++ b/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
@@ -3,10 +3,7 @@ package com.heylocal.traveler.domain.plan;
 import com.heylocal.traveler.domain.BaseTimeEntity;
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.user.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -23,6 +20,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class Plan extends BaseTimeEntity {
   @Id

--- a/src/main/java/com/heylocal/traveler/domain/plan/list/PlaceItem.java
+++ b/src/main/java/com/heylocal/traveler/domain/plan/list/PlaceItem.java
@@ -3,7 +3,10 @@ package com.heylocal.traveler.domain.plan.list;
 import com.heylocal.traveler.domain.BaseTimeEntity;
 import com.heylocal.traveler.domain.place.Place;
 import com.heylocal.traveler.domain.plan.DaySchedule;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;

--- a/src/main/java/com/heylocal/traveler/domain/profile/UserProfile.java
+++ b/src/main/java/com/heylocal/traveler/domain/profile/UserProfile.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -19,6 +20,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class UserProfile extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/token/AccessToken.java
+++ b/src/main/java/com/heylocal/traveler/domain/token/AccessToken.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class AccessToken extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/token/RefreshToken.java
+++ b/src/main/java/com/heylocal/traveler/domain/token/RefreshToken.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class RefreshToken extends BaseTimeEntity {
   @Id

--- a/src/main/java/com/heylocal/traveler/domain/travelon/TravelOn.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/TravelOn.java
@@ -9,10 +9,7 @@ import com.heylocal.traveler.domain.travelon.list.HopeFood;
 import com.heylocal.traveler.domain.travelon.list.TravelMember;
 import com.heylocal.traveler.domain.travelon.opinion.Opinion;
 import com.heylocal.traveler.domain.user.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -29,6 +26,7 @@ import java.util.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class TravelOn extends BaseTimeEntity {
   @Id @GeneratedValue
@@ -136,7 +134,7 @@ public class TravelOn extends BaseTimeEntity {
   public void addOpinion(Opinion opinion) {
     this.opinionList.add(opinion);
     if (opinion.getTravelOn() != this) {
-      opinion.registerTravelOn(this);
+      opinion.setTravelOn(this);
     }
   }
 

--- a/src/main/java/com/heylocal/traveler/domain/travelon/TravelTypeGroup.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/TravelTypeGroup.java
@@ -4,6 +4,7 @@ import com.heylocal.traveler.domain.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -16,6 +17,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class TravelTypeGroup extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/travelon/list/HopeAccommodation.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/list/HopeAccommodation.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.travelon.TravelOn;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -18,6 +19,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class HopeAccommodation extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/travelon/list/HopeDrink.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/list/HopeDrink.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.travelon.TravelOn;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -17,6 +18,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class HopeDrink extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/travelon/list/HopeFood.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/list/HopeFood.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.travelon.TravelOn;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -14,6 +15,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class HopeFood extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/travelon/list/TravelMember.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/list/TravelMember.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.domain.travelon.TravelOn;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -17,6 +18,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class TravelMember extends BaseTimeEntity {
   @Id @GeneratedValue

--- a/src/main/java/com/heylocal/traveler/domain/travelon/opinion/Opinion.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/opinion/Opinion.java
@@ -5,10 +5,7 @@ import com.heylocal.traveler.domain.Region;
 import com.heylocal.traveler.domain.place.Place;
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.user.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -24,6 +21,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class Opinion extends BaseTimeEntity {
   @Id @GeneratedValue
@@ -96,38 +94,38 @@ public class Opinion extends BaseTimeEntity {
   @OneToMany(mappedBy = "opinion", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY) //Opinion 이 삭제되어도, S3에 저장된 경로를 알아야하므로 Cascade를 Persist만 설정
   private List<OpinionImageContent> opinionImageContentList = new ArrayList<>();
 
-  public void registerTravelOn(TravelOn travelOn) {
+  public void setTravelOn(TravelOn travelOn) {
     this.travelOn = travelOn;
     if (!travelOn.getOpinionList().contains(this)) {
       travelOn.addOpinion(this);
     }
   }
 
-  public void registerPlace(Place place) {
+  public void setPlace(Place place) {
     this.place = place;
     if (!place.getOpinionList().contains(this)) {
       place.addOpinion(this);
     }
   }
 
-  public void registerAuthor(User author) {
+  public void setAuthor(User author) {
     this.author = author;
     if (!author.getOpinionList().contains(this)) {
       author.addOpinion(this);
     }
   }
 
-  public void registerRegion(Region region) {
+  public void setRegion(Region region) {
     this.region = region;
     if (!region.getOpinionList().contains(this)) {
       region.addOpinion(this);
     }
   }
 
-  public void addOpinionImgContent(OpinionImageContent imgContent) {
+  public void setOpinionImageContentList(OpinionImageContent imgContent) {
     this.opinionImageContentList.add(imgContent);
     if (imgContent.getOpinion() != this) {
-      imgContent.registerOpinion(this);
+      imgContent.setOpinion(this);
     }
   }
 
@@ -137,14 +135,14 @@ public class Opinion extends BaseTimeEntity {
     if (!Objects.isNull(this.place)) {
       this.place.removeOpinion(this);
     }
-    registerPlace(newValue);
+    setPlace(newValue);
   }
 
   public void updateRegion(Region newValue) {
     if (!Objects.isNull(this.region)) {
       this.region.removeOpinion(this);
     }
-    registerRegion(newValue);
+    setRegion(newValue);
   }
 
   public void updateDescription(String newValue) {

--- a/src/main/java/com/heylocal/traveler/domain/travelon/opinion/OpinionImageContent.java
+++ b/src/main/java/com/heylocal/traveler/domain/travelon/opinion/OpinionImageContent.java
@@ -31,10 +31,10 @@ public class OpinionImageContent extends BaseTimeEntity {
   @Column(nullable = false)
   private ImageContentType imageContentType;
 
-  public void registerOpinion(Opinion opinion) {
+  public void setOpinion(Opinion opinion) {
     this.opinion = opinion;
     if (!opinion.getOpinionImageContentList().contains(this)) {
-      opinion.addOpinionImgContent(this);
+      opinion.setOpinionImageContentList(this);
     }
   }
 

--- a/src/main/java/com/heylocal/traveler/domain/user/User.java
+++ b/src/main/java/com/heylocal/traveler/domain/user/User.java
@@ -8,10 +8,7 @@ import com.heylocal.traveler.domain.token.AccessToken;
 import com.heylocal.traveler.domain.token.RefreshToken;
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.travelon.opinion.Opinion;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -27,6 +24,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @SuperBuilder
 public class User extends BaseTimeEntity {
   @Id @GeneratedValue
@@ -101,7 +99,7 @@ public class User extends BaseTimeEntity {
   public void addOpinion(Opinion opinion) {
     this.opinionList.add(opinion);
     if (opinion.getAuthor() != this) {
-      opinion.registerAuthor(this);
+      opinion.setAuthor(this);
     }
   }
 }

--- a/src/main/java/com/heylocal/traveler/dto/HopeAccommodationDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/HopeAccommodationDto.java
@@ -1,7 +1,6 @@
 package com.heylocal.traveler.dto;
 
 import com.heylocal.traveler.domain.travelon.list.AccommodationType;
-import com.heylocal.traveler.domain.travelon.list.HopeAccommodation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/heylocal/traveler/dto/HopeAccommodationDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/HopeAccommodationDto.java
@@ -15,10 +15,5 @@ public class HopeAccommodationDto {
   public static class HopeAccommodationResponse {
     private long id;
     private AccommodationType type;
-
-    public HopeAccommodationResponse(HopeAccommodation entity) {
-      this.id = entity.getId();
-      this.type = entity.getType();
-    }
   }
 }

--- a/src/main/java/com/heylocal/traveler/dto/HopeDrinkDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/HopeDrinkDto.java
@@ -15,10 +15,5 @@ public class HopeDrinkDto {
   public static class HopeDrinkResponse {
     private long id;
     private DrinkType type;
-
-    public HopeDrinkResponse(HopeDrink entity) {
-      this.id = entity.getId();
-      this.type = entity.getType();
-    }
   }
 }

--- a/src/main/java/com/heylocal/traveler/dto/HopeDrinkDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/HopeDrinkDto.java
@@ -1,7 +1,6 @@
 package com.heylocal.traveler.dto;
 
 import com.heylocal.traveler.domain.travelon.list.DrinkType;
-import com.heylocal.traveler.domain.travelon.list.HopeDrink;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/heylocal/traveler/dto/HopeFoodDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/HopeFoodDto.java
@@ -1,7 +1,6 @@
 package com.heylocal.traveler.dto;
 
 import com.heylocal.traveler.domain.travelon.list.FoodType;
-import com.heylocal.traveler.domain.travelon.list.HopeFood;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/heylocal/traveler/dto/HopeFoodDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/HopeFoodDto.java
@@ -15,10 +15,5 @@ public class HopeFoodDto {
   public static class HopeFoodResponse {
     private long id;
     private FoodType type;
-
-    public HopeFoodResponse(HopeFood entity) {
-      this.id = entity.getId();
-      this.type = entity.getType();
-    }
   }
 }

--- a/src/main/java/com/heylocal/traveler/dto/OpinionDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/OpinionDto.java
@@ -1,11 +1,9 @@
 package com.heylocal.traveler.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.heylocal.traveler.domain.Region;
-import com.heylocal.traveler.domain.place.Place;
-import com.heylocal.traveler.domain.travelon.TravelOn;
-import com.heylocal.traveler.domain.travelon.opinion.*;
-import com.heylocal.traveler.domain.user.User;
+import com.heylocal.traveler.domain.travelon.opinion.CafeMoodType;
+import com.heylocal.traveler.domain.travelon.opinion.CoffeeType;
+import com.heylocal.traveler.domain.travelon.opinion.EvaluationDegree;
+import com.heylocal.traveler.domain.travelon.opinion.RestaurantMoodType;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,12 +11,8 @@ import lombok.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static com.heylocal.traveler.domain.travelon.opinion.OpinionImageContent.*;
-import static com.heylocal.traveler.dto.OpinionImageContentDto.OpinionImageContentResponse;
 import static com.heylocal.traveler.dto.PlaceDto.PlaceRequest;
 import static com.heylocal.traveler.dto.PlaceDto.PlaceResponse;
 import static com.heylocal.traveler.dto.UserDto.UserResponse;
@@ -89,90 +83,6 @@ public class OpinionDto {
 
 		@ApiModelProperty("조식이 나오나요")
 		private Boolean hasBreakFast;
-
-		public Opinion toEntity(Place place, User author, TravelOn travelOn, Region region) {
-			Opinion opinion = Opinion.builder()
-					.description(description)
-					.facilityCleanliness(facilityCleanliness)
-					.costPerformance(costPerformance)
-					.canParking(canParking)
-					.waiting(waiting)
-					.restaurantMoodType(restaurantMoodType)
-					.recommendFoodDescription(recommendFoodDescription)
-					.coffeeType(coffeeType)
-					.cafeMoodType(cafeMoodType)
-					.recommendToDo(recommendToDo)
-					.recommendSnack(recommendSnack)
-					.photoSpotDescription(photoSpotDescription)
-					.streetNoise(streetNoise)
-					.deafening(deafening)
-					.hasBreakFast(hasBreakFast)
-					.build();
-
-			opinion.registerPlace(place);
-			opinion.registerAuthor(author);
-			opinion.registerTravelOn(travelOn);
-			opinion.registerRegion(region);
-
-			setEntityWithGeneralImgContents(opinion);
-			setEntityWithFoodImgContents(opinion);
-			setEntityWithDrinkAndDessertImgContents(opinion);
-			setEntityWithPhotoSpotImgContents(opinion);
-
-			return opinion;
-		}
-
-		@JsonIgnore
-		private void setEntityWithGeneralImgContents(Opinion entity) {
-			this.generalImgContentUrlList.stream().forEach(
-					(item) -> {
-						OpinionImageContent imgContentEntity = OpinionImageContent.builder()
-								.url(item)
-								.imageContentType(ImageContentType.GENERAL)
-								.build();
-						imgContentEntity.registerOpinion(entity);
-					}
-			);
-		}
-
-		@JsonIgnore
-		private void setEntityWithFoodImgContents(Opinion entity) {
-			this.foodImgContentUrlList.stream().forEach(
-					(item) -> {
-						OpinionImageContent imgContentEntity = OpinionImageContent.builder()
-								.url(item)
-								.imageContentType(ImageContentType.RECOMMEND_FOOD)
-								.build();
-						imgContentEntity.registerOpinion(entity);
-					}
-			);
-		}
-
-		@JsonIgnore
-		private void setEntityWithDrinkAndDessertImgContents(Opinion entity) {
-			this.drinkAndDessertImgContentUrlList.stream().forEach(
-					(item) -> {
-						OpinionImageContent imgContentEntity = OpinionImageContent.builder()
-								.url(item)
-								.imageContentType(ImageContentType.RECOMMEND_DRINK_DESSERT)
-								.build();
-						imgContentEntity.registerOpinion(entity);
-					}
-			);
-		}
-
-		@JsonIgnore
-		private void setEntityWithPhotoSpotImgContents(Opinion entity) {
-			this.photoSpotImgContentUrlList.stream().forEach(
-					(item) -> {
-						OpinionImageContent imgContentEntity = OpinionImageContent.builder()
-								.url(item)
-								.imageContentType(ImageContentType.PHOTO_SPOT)
-								.build();
-						imgContentEntity.registerOpinion(entity);
-					}
-			);
-		}
 	}
 
 	@Getter
@@ -215,68 +125,5 @@ public class OpinionDto {
 		private EvaluationDegree streetNoise;
 		private EvaluationDegree deafening;
 		private Boolean hasBreakFast;
-
-		public OpinionResponse(Opinion entity) {
-			this.id = entity.getId();
-			this.description = entity.getDescription();
-			this.author = new UserResponse(entity.getAuthor());
-			this.place = new PlaceResponse(entity.getPlace());
-
-			//공통 질문
-			this.facilityCleanliness = entity.getFacilityCleanliness();
-			this.costPerformance = entity.getCostPerformance();
-			this.canParking = entity.getCanParking();
-			this.waiting = entity.getWaiting();
-
-			//음식점 전용 항목
-			this.restaurantMoodType = entity.getRestaurantMoodType();
-			this.recommendFoodDescription = entity.getRecommendFoodDescription();
-
-			//카페 전용 항목
-			this.coffeeType = entity.getCoffeeType();
-			this.recommendDrinkAndDessertDescription = entity.getRecommendDrinkAndDessertDescription();
-			this.cafeMoodType = entity.getCafeMoodType();
-
-			//문화시설, 관광명소 전용 항목
-			this.recommendToDo = entity.getRecommendToDo();
-			this.recommendSnack = entity.getRecommendSnack();
-			this.photoSpotDescription = entity.getPhotoSpotDescription();
-
-			//숙박 전용
-			this.streetNoise = entity.getStreetNoise();
-			this.deafening = entity.getDeafening();
-			this.hasBreakFast = entity.getHasBreakFast();
-
-			setAllImgContentsList(entity.getOpinionImageContentList());
-		}
-
-		@JsonIgnore
-		private void setAllImgContentsList(List<OpinionImageContent> opinionImageContentEntityList) {
-			this.generalImgContentUrlList = new ArrayList<>();
-			this.foodImgContentUrlList = new ArrayList<>();
-			this.drinkAndDessertImgContentUrlList = new ArrayList<>();
-			this.photoSpotImgContentUrlList = new ArrayList<>();
-
-			opinionImageContentEntityList.stream().forEach(
-					(item) -> {
-						ImageContentType imgType = item.getImageContentType();
-						String imgUrl = item.getUrl();
-						switch (imgType) {
-							case GENERAL:
-								generalImgContentUrlList.add(imgUrl);
-								break;
-							case RECOMMEND_FOOD:
-								foodImgContentUrlList.add(imgUrl);
-								break;
-							case RECOMMEND_DRINK_DESSERT:
-								drinkAndDessertImgContentUrlList.add(imgUrl);
-								break;
-							case PHOTO_SPOT:
-								photoSpotImgContentUrlList.add(imgUrl);
-								break;
-						}
-					}
-			);
-		}
 	}
 }

--- a/src/main/java/com/heylocal/traveler/dto/OpinionImageContentDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/OpinionImageContentDto.java
@@ -1,8 +1,9 @@
 package com.heylocal.traveler.dto;
 
-import com.heylocal.traveler.domain.travelon.opinion.OpinionImageContent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+
+import static com.heylocal.traveler.domain.travelon.opinion.OpinionImageContent.ImageContentType;
 
 public class OpinionImageContentDto {
   @Getter
@@ -13,11 +14,7 @@ public class OpinionImageContentDto {
   @Schema(description = "여행 On에 대한 답변 응답 DTO")
   public static class OpinionImageContentResponse {
     private long id;
+    private ImageContentType imageContentType;
     private String url;
-
-    public OpinionImageContentResponse(OpinionImageContent entity) {
-      this.id = entity.getId();
-      this.url = entity.getUrl();
-    }
   }
 }

--- a/src/main/java/com/heylocal/traveler/dto/PlaceDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/PlaceDto.java
@@ -87,19 +87,6 @@ public class PlaceDto {
 		private RegionResponse region;
 		private String thumbnailUrl;
 		private String kakaoLink;
-
-		public PlaceResponse(Place entity) {
-			this.id = entity.getId();
-			this.category = entity.getCategory();
-			this.name = entity.getName();
-			this.roadAddress = entity.getRoadAddress();
-			this.address = entity.getAddress();
-			this.lat = entity.getLat();
-			this.lng = entity.getLng();
-			this.region = new RegionResponse(entity.getRegion());
-			this.thumbnailUrl = entity.getThumbnailUrl();
-			this.kakaoLink = entity.getLink();
-		}
 	}
 
 	@Getter
@@ -153,15 +140,5 @@ public class PlaceDto {
 		String roadAddress;
 		double lat;
 		double lng;
-
-		public PlaceItemResponse(PlaceItem placeItem) {
-			Place place = placeItem.getPlace();
-			this.id = place.getId();
-			this.name = place.getName();
-			this.address = place.getAddress();
-			this.roadAddress = place.getRoadAddress();
-			this.lat = place.getLat();
-			this.lng = place.getLng();
-		}
 	}
 }

--- a/src/main/java/com/heylocal/traveler/dto/PlaceDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/PlaceDto.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
-import static com.heylocal.traveler.dto.RegionDto.*;
+import static com.heylocal.traveler.dto.RegionDto.RegionResponse;
 
 public class PlaceDto {
 

--- a/src/main/java/com/heylocal/traveler/dto/PlanDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/PlanDto.java
@@ -1,13 +1,9 @@
 package com.heylocal.traveler.dto;
 
-import com.heylocal.traveler.domain.Region;
 import com.heylocal.traveler.domain.plan.DaySchedule;
-import com.heylocal.traveler.domain.plan.Plan;
 import com.heylocal.traveler.domain.plan.list.PlaceItem;
-import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.dto.PlaceDto.PlaceItemRequest;
 import com.heylocal.traveler.dto.PlaceDto.PlaceItemResponse;
-import com.heylocal.traveler.mapper.PlaceMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/heylocal/traveler/dto/PlanDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/PlanDto.java
@@ -7,6 +7,7 @@ import com.heylocal.traveler.domain.plan.list.PlaceItem;
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.dto.PlaceDto.PlaceItemRequest;
 import com.heylocal.traveler.dto.PlaceDto.PlaceItemResponse;
+import com.heylocal.traveler.mapper.PlaceMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -51,18 +52,6 @@ public class PlanDto {
 		// String regionThumbUrl;
 		LocalDate startDate;
 		LocalDate endDate;
-
-		public PlanResponse(Plan plan) {
-			TravelOn travelOn = plan.getTravelOn();
-			Region region = travelOn.getRegion();
-
-			this.id = plan.getId();
-			this.regionId = region.getId();
-			this.regionState = region.getState();
-			this.regionCity = region.getCity();
-			this.startDate = travelOn.getTravelStartDate();
-			this.endDate = travelOn.getTravelEndDate();
-		}
 	}
 
 	@Getter
@@ -116,13 +105,5 @@ public class PlanDto {
 	public static class PlanPlacesResponse {
 		LocalDate date;
 		List<PlaceItemResponse> places;
-
-		public PlanPlacesResponse(DaySchedule daySchedule) {
-			List<PlaceItem> placeItems = daySchedule.getPlaceItemList();
-			this.date = daySchedule.getDateTime();
-			this.places = placeItems.stream()
-					.map(PlaceItemResponse::new)
-					.collect(Collectors.toList());
-		}
 	}
 }

--- a/src/main/java/com/heylocal/traveler/dto/RegionDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/RegionDto.java
@@ -1,6 +1,5 @@
 package com.heylocal.traveler.dto;
 
-import com.heylocal.traveler.domain.Region;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/heylocal/traveler/dto/RegionDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/RegionDto.java
@@ -30,11 +30,5 @@ public class RegionDto {
 		private long id;
 		private String state;
 		private String city;
-
-		public RegionResponse(Region entity) {
-			this.id = entity.getId();
-			this.state = entity.getState();
-			this.city = entity.getCity();
-		}
 	}
 }

--- a/src/main/java/com/heylocal/traveler/dto/TravelMemberDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/TravelMemberDto.java
@@ -1,7 +1,6 @@
 package com.heylocal.traveler.dto;
 
 import com.heylocal.traveler.domain.travelon.list.MemberType;
-import com.heylocal.traveler.domain.travelon.list.TravelMember;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/heylocal/traveler/dto/TravelMemberDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/TravelMemberDto.java
@@ -15,10 +15,5 @@ public class TravelMemberDto {
   public static class TravelMemberResponse {
     private long id;
     private MemberType type;
-
-    public TravelMemberResponse(TravelMember entity) {
-      this.id = entity.getId();
-      this.type = entity.getMemberType();
-    }
   }
 }

--- a/src/main/java/com/heylocal/traveler/dto/TravelOnDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/TravelOnDto.java
@@ -1,11 +1,10 @@
 package com.heylocal.traveler.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.heylocal.traveler.domain.Region;
 import com.heylocal.traveler.domain.travelon.TransportationType;
-import com.heylocal.traveler.domain.travelon.TravelOn;
-import com.heylocal.traveler.domain.travelon.list.*;
-import com.heylocal.traveler.domain.user.User;
+import com.heylocal.traveler.domain.travelon.list.AccommodationType;
+import com.heylocal.traveler.domain.travelon.list.DrinkType;
+import com.heylocal.traveler.domain.travelon.list.FoodType;
+import com.heylocal.traveler.domain.travelon.list.MemberType;
 import com.heylocal.traveler.dto.TravelTypeGroupDto.TravelTypeGroupRequest;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,7 +19,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.heylocal.traveler.dto.HopeAccommodationDto.HopeAccommodationResponse;
 import static com.heylocal.traveler.dto.HopeDrinkDto.HopeDrinkResponse;
@@ -53,102 +51,22 @@ public class TravelOnDto {
 		@NotNull
 		private TransportationType transportationType;
 		@NotEmpty
+		@Builder.Default
 		private Set<MemberType> memberTypeSet = new HashSet<>();
 		private int accommodationMaxCost;
 		@NotEmpty
+		@Builder.Default
 		private Set<AccommodationType> accommodationTypeSet = new HashSet<>();
 		private int foodMaxCost;
 		@NotEmpty
+		@Builder.Default
 		private Set<FoodType> foodTypeSet = new HashSet<>();
 		private int drinkMaxCost;
 		@NotEmpty
+		@Builder.Default
 		private Set<DrinkType> drinkTypeSet = new HashSet<>();
 		@Valid
 		private TravelTypeGroupRequest travelTypeGroup;
-
-		/**
-		 * 새로운 TravelOn 엔티티를 만드는 메서드
-		 * @param author 이 존재하는 User 엔티티
-		 * @param region 이미 존재하는 Region 엔티티
-		 * @return
-		 */
-		public TravelOn toEntity(User author, Region region) {
-			TravelOn travelOn;
-
-			travelOn = TravelOn.builder()
-					.title(title)
-					.region(region)
-					.author(author)
-					.views(0)
-					.travelStartDate(travelStartDate)
-					.travelEndDate(travelEndDate)
-					.description(description)
-					.transportationType(transportationType)
-					.accommodationMaxCost(accommodationMaxCost)
-					.foodMaxCost(foodMaxCost)
-					.drinkMaxCost(drinkMaxCost)
-					.build();
-
-			setEntityWithTravelMember(travelOn);
-			setEntityWithHopeAccommodation(travelOn);
-			setEntityWithHopeFood(travelOn);
-			setEntityWithHopeDrink(travelOn);
-			travelOn.registerTravelTypeGroup(travelTypeGroup.toEntity());
-
-			return travelOn;
-		}
-
-		@JsonIgnore
-		private void setEntityWithHopeDrink(TravelOn travelOn) {
-			this.drinkTypeSet.stream().forEach(
-					(item) -> {
-						HopeDrink hopeDrink = HopeDrink.builder()
-										.travelOn(travelOn)
-										.type(item)
-										.build();
-						travelOn.addHopeDrink(hopeDrink);
-					}
-			);
-		}
-
-		@JsonIgnore
-		private void setEntityWithHopeFood(TravelOn travelOn) {
-			this.foodTypeSet.stream().forEach(
-					(item) -> {
-						HopeFood hopeFood = HopeFood.builder()
-								.travelOn(travelOn)
-								.type(item)
-								.build();
-						travelOn.addHopeFood(hopeFood);
-					}
-			);
-		}
-
-		@JsonIgnore
-		private void setEntityWithHopeAccommodation(TravelOn travelOn) {
-			this.accommodationTypeSet.stream().forEach(
-					(item) -> {
-						HopeAccommodation hopeAccommodation = HopeAccommodation.builder()
-										.travelOn(travelOn)
-										.type(item)
-										.build();
-						travelOn.addHopeAccommodation(hopeAccommodation);
-					}
-			);
-		}
-
-		@JsonIgnore
-		private void setEntityWithTravelMember(TravelOn travelOn) {
-			this.memberTypeSet.stream().forEach(
-					(item) -> {
-						TravelMember travelMember = TravelMember.builder()
-										.travelOn(travelOn)
-										.memberType(item)
-										.build();
-						travelOn.addTravelMember(travelMember);
-					}
-			);
-		}
 	}
 
 	@Getter
@@ -194,52 +112,6 @@ public class TravelOnDto {
 		private TravelTypeGroupResponse travelTypeGroup;
 		private LocalDateTime createdDateTime;
 		private LocalDateTime modifiedDate;
-
-		public TravelOnResponse(TravelOn entity) {
-			this.id = entity.getId();
-			this.title = entity.getTitle();
-			this.description = entity.getDescription();
-			this.views = entity.getViews();
-			this.region = new RegionResponse(entity.getRegion());
-			this.author = new UserResponse(entity.getAuthor());
-			this.travelStartDate = entity.getTravelStartDate();
-			this.travelEndDate = entity.getTravelEndDate();
-			this.transportationType = entity.getTransportationType();
-			setTravelMemberSet(entity.getTravelMemberSet());
-			this.accommodationMaxCost = entity.getAccommodationMaxCost();
-			setHopeAccommodationSet(entity.getHopeAccommodationSet());
-			this.foodMaxCost = entity.getFoodMaxCost();
-			setHopeFoodSet(entity.getHopeFoodSet());
-			this.drinkMaxCost = entity.getDrinkMaxCost();
-			setHopeDrinkSet(entity.getHopeDrinkSet());
-			this.travelTypeGroup = new TravelTypeGroupResponse(entity.getTravelTypeGroup());
-			this.createdDateTime = entity.getCreatedDate();
-			this.modifiedDate = entity.getModifiedDate();
-		}
-
-		public void setTravelMemberSet(Set<TravelMember> travelMemberSet) {
-			this.travelMemberSet = travelMemberSet.stream()
-					.map(TravelMemberResponse::new)
-					.collect(Collectors.toSet());
-		}
-
-		public void setHopeAccommodationSet(Set<HopeAccommodation> hopeAccommodationSet) {
-			this.hopeAccommodationSet = hopeAccommodationSet.stream()
-					.map(HopeAccommodationResponse::new)
-					.collect(Collectors.toSet());
-		}
-
-		public void setHopeFoodSet(Set<HopeFood> hopeFoodSet) {
-			this.hopeFoodSet = hopeFoodSet.stream()
-					.map(HopeFoodResponse::new)
-					.collect(Collectors.toSet());
-		}
-
-		public void setHopeDrinkSet(Set<HopeDrink> hopeDrinkSet) {
-			this.hopeDrinkSet = hopeDrinkSet.stream()
-					.map(HopeDrinkResponse::new)
-					.collect(Collectors.toSet());
-		}
 	}
 
 	@Getter
@@ -258,18 +130,6 @@ public class TravelOnDto {
 		private String description;
 		private int views;
 		private int opinionQuantity;
-
-		public TravelOnSimpleResponse(TravelOn entity) {
-			this.id = entity.getId();
-			this.title = entity.getTitle();
-			this.region = new RegionResponse(entity.getRegion());
-			this.createdDateTime = entity.getCreatedDate();
-			this.modifiedDate = entity.getModifiedDate();
-			this.author = new UserResponse(entity.getAuthor());
-			this.description = entity.getDescription();
-			this.views = entity.getViews();
-			this.opinionQuantity = entity.getOpinionList().size();
-		}
 	}
 
 	public enum TravelOnSortType {

--- a/src/main/java/com/heylocal/traveler/dto/TravelTypeGroupDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/TravelTypeGroupDto.java
@@ -3,7 +3,6 @@ package com.heylocal.traveler.dto;
 import com.heylocal.traveler.domain.travelon.ActivityTasteType;
 import com.heylocal.traveler.domain.travelon.PlaceTasteType;
 import com.heylocal.traveler.domain.travelon.SnsTasteType;
-import com.heylocal.traveler.domain.travelon.TravelTypeGroup;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/heylocal/traveler/dto/TravelTypeGroupDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/TravelTypeGroupDto.java
@@ -23,14 +23,6 @@ public class TravelTypeGroupDto {
     private ActivityTasteType activityTasteType;
     @NotNull
     private SnsTasteType snsTasteType;
-
-    public TravelTypeGroup toEntity() {
-      return TravelTypeGroup.builder()
-          .placeTasteType(placeTasteType)
-          .activityTasteType(activityTasteType)
-          .snsTasteType(snsTasteType)
-          .build();
-    }
   }
 
   @Getter
@@ -44,12 +36,5 @@ public class TravelTypeGroupDto {
     private PlaceTasteType placeTasteType;
     private ActivityTasteType activityTasteType;
     private SnsTasteType snsTasteType;
-
-    public TravelTypeGroupResponse(TravelTypeGroup entity) {
-      this.id = entity.getId();
-      this.placeTasteType = entity.getPlaceTasteType();
-      this.activityTasteType = entity.getActivityTasteType();
-      this.snsTasteType = entity.getSnsTasteType();
-    }
   }
 }

--- a/src/main/java/com/heylocal/traveler/dto/UserDto.java
+++ b/src/main/java/com/heylocal/traveler/dto/UserDto.java
@@ -1,7 +1,5 @@
 package com.heylocal.traveler.dto;
 
-import com.heylocal.traveler.domain.profile.UserProfile;
-import com.heylocal.traveler.domain.user.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -28,13 +26,6 @@ public class UserDto {
 		String nickname;
 		int knowHow;
 		long ranking;
-
-		public UserProfileResponse(UserProfile entity, long ranking) {
-			this.imageUrl = entity.getImageUrl();
-			this.nickname = entity.getUser().getNickname();
-			this.knowHow = entity.getKnowHow();
-			this.ranking = ranking;
-		}
 	}
 
 	@Getter
@@ -49,13 +40,5 @@ public class UserDto {
 		private String nickname;
 		private String imageUrl;
 		private int knowHow;
-
-		public UserResponse(User user) {
-			this.id = user.getId();
-			this.accountId = user.getAccountId();
-			this.nickname = user.getNickname();
-			this.imageUrl = user.getUserProfile().getImageUrl();
-			this.knowHow = user.getUserProfile().getKnowHow();
-		}
 	}
 }

--- a/src/main/java/com/heylocal/traveler/mapper/HopeAccommodationMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/HopeAccommodationMapper.java
@@ -1,0 +1,25 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.list.AccommodationType;
+import com.heylocal.traveler.domain.travelon.list.DrinkType;
+import com.heylocal.traveler.domain.travelon.list.HopeAccommodation;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.HopeAccommodationDto.HopeAccommodationResponse;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface HopeAccommodationMapper {
+  HopeAccommodationMapper INSTANCE = Mappers.getMapper(HopeAccommodationMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  HopeAccommodation toEntity(TravelOn travelOn, AccommodationType type);
+
+  HopeAccommodationResponse toResponseDto(HopeAccommodation hopeAccommodation);
+
+  @AfterMapping
+  default void registerTravelOnToEntity(TravelOn travelOn, @MappingTarget HopeAccommodation hopeAccommodation) {
+    hopeAccommodation.registerAt(travelOn);
+  }
+}

--- a/src/main/java/com/heylocal/traveler/mapper/HopeAccommodationMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/HopeAccommodationMapper.java
@@ -2,7 +2,6 @@ package com.heylocal.traveler.mapper;
 
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.travelon.list.AccommodationType;
-import com.heylocal.traveler.domain.travelon.list.DrinkType;
 import com.heylocal.traveler.domain.travelon.list.HopeAccommodation;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;

--- a/src/main/java/com/heylocal/traveler/mapper/HopeDrinkMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/HopeDrinkMapper.java
@@ -1,0 +1,24 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.list.DrinkType;
+import com.heylocal.traveler.domain.travelon.list.HopeDrink;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.HopeDrinkDto.HopeDrinkResponse;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface HopeDrinkMapper {
+  HopeDrinkMapper INSTANCE = Mappers.getMapper(HopeDrinkMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  HopeDrink toEntity(TravelOn travelOn, DrinkType type);
+
+  HopeDrinkResponse toResponseDto(HopeDrink hopeDrink);
+
+  @AfterMapping
+  default void registerTravelOnToEntity(TravelOn travelOn, @MappingTarget HopeDrink hopeDrink) {
+    hopeDrink.registerAt(travelOn);
+  }
+}

--- a/src/main/java/com/heylocal/traveler/mapper/HopeFoodMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/HopeFoodMapper.java
@@ -1,0 +1,24 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.list.FoodType;
+import com.heylocal.traveler.domain.travelon.list.HopeFood;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.HopeFoodDto.HopeFoodResponse;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface HopeFoodMapper {
+  HopeFoodMapper INSTANCE = Mappers.getMapper(HopeFoodMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  HopeFood toEntity(TravelOn travelOn, FoodType type);
+
+  HopeFoodResponse toResponseDto(HopeFood hopeFood);
+
+  @AfterMapping
+  default void registerTravelOnToEntity(TravelOn travelOn, @MappingTarget HopeFood hopeFood) {
+    hopeFood.registerAt(travelOn);
+  }
+}

--- a/src/main/java/com/heylocal/traveler/mapper/OpinionImageContentMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/OpinionImageContentMapper.java
@@ -1,8 +1,6 @@
 package com.heylocal.traveler.mapper;
 
-import com.heylocal.traveler.domain.travelon.opinion.Opinion;
 import com.heylocal.traveler.domain.travelon.opinion.OpinionImageContent;
-import com.heylocal.traveler.dto.OpinionImageContentDto;
 import com.heylocal.traveler.dto.OpinionImageContentDto.OpinionImageContentResponse;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;

--- a/src/main/java/com/heylocal/traveler/mapper/OpinionImageContentMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/OpinionImageContentMapper.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.travelon.opinion.Opinion;
+import com.heylocal.traveler.domain.travelon.opinion.OpinionImageContent;
+import com.heylocal.traveler.dto.OpinionImageContentDto;
+import com.heylocal.traveler.dto.OpinionImageContentDto.OpinionImageContentResponse;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface OpinionImageContentMapper {
+  OpinionImageContentMapper INSTANCE = Mappers.getMapper(OpinionImageContentMapper.class);
+
+  OpinionImageContentResponse toResponseDto(OpinionImageContent opinionImageContent);
+}

--- a/src/main/java/com/heylocal/traveler/mapper/OpinionMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/OpinionMapper.java
@@ -1,0 +1,116 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.Region;
+import com.heylocal.traveler.domain.place.Place;
+import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.opinion.Opinion;
+import com.heylocal.traveler.domain.travelon.opinion.OpinionImageContent;
+import com.heylocal.traveler.domain.user.User;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.heylocal.traveler.domain.travelon.opinion.OpinionImageContent.ImageContentType;
+import static com.heylocal.traveler.dto.OpinionDto.OpinionRequest;
+import static com.heylocal.traveler.dto.OpinionDto.OpinionResponse;
+
+/**
+ * target에 Lombok 의 @Builder 를 사용하면 @AfterMapping 이 제대로 동작하지 않는 버그가 존재함.
+ * 따라서, builder = @Builder(disableBuilder = true) 를 설정함.
+ */
+@Mapper(uses = {UserMapper.class, PlaceMapper.class}, imports = {OpinionImageContent.class}, builder = @Builder(disableBuilder = true))
+public interface OpinionMapper {
+  OpinionMapper INSTANCE = Mappers.getMapper(OpinionMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "createdDate", ignore = true)
+  @Mapping(target = "modifiedDate", ignore = true)
+  @Mapping(target = "description", source = "opinionRequest.description")
+  @Mapping(target = "place", source = "place")
+  @Mapping(target = "author", source = "author")
+  @Mapping(target = "region", source = "region")
+  @Mapping(target = "opinionImageContentList", ignore = true)
+  Opinion toEntity(OpinionRequest opinionRequest, Place place, User author, TravelOn travelOn, Region region);
+
+  @Mapping(target = "generalImgContentUrlList", ignore = true)
+  @Mapping(target = "foodImgContentUrlList", ignore = true)
+  @Mapping(target = "drinkAndDessertImgContentUrlList", ignore = true)
+  @Mapping(target = "photoSpotImgContentUrlList", ignore = true)
+  OpinionResponse toResponseDto(Opinion opinion);
+
+  @AfterMapping
+  default void updateResponseDtoImgContentList(Opinion opinion, @MappingTarget OpinionResponse opinionResponse) {
+    List<String> generalUrlList = new ArrayList<>();
+    List<String> foodUrlList = new ArrayList<>();
+    List<String> drinkAndDessertUrlList = new ArrayList<>();
+    List<String> photoSpotUrlList = new ArrayList<>();
+
+    opinion.getOpinionImageContentList().stream().forEach(
+        (item) -> {
+          ImageContentType type = item.getImageContentType();
+          switch (type) {
+            case GENERAL:
+              generalUrlList.add(item.getUrl());
+              break;
+            case RECOMMEND_FOOD:
+              foodUrlList.add(item.getUrl());
+              break;
+            case RECOMMEND_DRINK_DESSERT:
+              drinkAndDessertUrlList.add(item.getUrl());
+              break;
+            case PHOTO_SPOT:
+              photoSpotUrlList.add(item.getUrl());
+              break;
+          }
+        }
+    );
+
+    opinionResponse.setGeneralImgContentUrlList(generalUrlList);
+    opinionResponse.setFoodImgContentUrlList(foodUrlList);
+    opinionResponse.setDrinkAndDessertImgContentUrlList(drinkAndDessertUrlList);
+    opinionResponse.setPhotoSpotImgContentUrlList(photoSpotUrlList);
+  }
+
+  @AfterMapping
+  default void updateEntityImgContentList(OpinionRequest opinionRequest, @MappingTarget Opinion opinion) {
+    opinionRequest.getGeneralImgContentUrlList().stream().forEach(
+        (item) -> {
+          OpinionImageContent imgContentEntity = OpinionImageContent.builder()
+              .url(item)
+              .imageContentType(ImageContentType.GENERAL)
+              .build();
+          imgContentEntity.setOpinion(opinion);
+        }
+    );
+    opinionRequest.getFoodImgContentUrlList().stream().forEach(
+        (item) -> {
+          OpinionImageContent imgContentEntity = OpinionImageContent.builder()
+              .url(item)
+              .imageContentType(ImageContentType.RECOMMEND_FOOD)
+              .build();
+          imgContentEntity.setOpinion(opinion);
+        }
+    );
+    opinionRequest.getDrinkAndDessertImgContentUrlList().stream().forEach(
+        (item) -> {
+          OpinionImageContent imgContentEntity = OpinionImageContent.builder()
+              .url(item)
+              .imageContentType(ImageContentType.RECOMMEND_DRINK_DESSERT)
+              .build();
+          imgContentEntity.setOpinion(opinion);
+        }
+    );
+    opinionRequest.getPhotoSpotImgContentUrlList().stream().forEach(
+        (item) -> {
+          OpinionImageContent imgContentEntity = OpinionImageContent.builder()
+              .url(item)
+              .imageContentType(ImageContentType.PHOTO_SPOT)
+              .build();
+          imgContentEntity.setOpinion(opinion);
+        }
+    );
+  }
+
+}

--- a/src/main/java/com/heylocal/traveler/mapper/PlaceMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/PlaceMapper.java
@@ -1,0 +1,38 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.Region;
+import com.heylocal.traveler.domain.place.Place;
+import com.heylocal.traveler.domain.plan.list.PlaceItem;
+import com.heylocal.traveler.dto.PlaceDto;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.PlaceDto.*;
+import static com.heylocal.traveler.dto.PlaceDto.PlaceItemResponse;
+import static com.heylocal.traveler.dto.PlaceDto.PlaceResponse;
+
+@Mapper(uses = {RegionMapper.class}, builder = @Builder(disableBuilder = true))
+public interface PlaceMapper {
+  PlaceMapper INSTANCE = Mappers.getMapper(PlaceMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "opinionList", ignore = true)
+  @Mapping(target = "placeItemList", ignore = true)
+  @Mapping(target = "link", source = "placeRequest.kakaoLink")
+  @Mapping(target = "region", source = "region")
+  @Mapping(target = "createdDate", ignore = true)
+  @Mapping(target = "modifiedDate", ignore = true)
+  Place toEntity(PlaceRequest placeRequest, Region region);
+
+  @Mapping(target = "kakaoLink", source = "link")
+  PlaceResponse toPlaceResponseDto(Place place);
+
+  @Mapping(target = "name", source = "placeItem.place.name")
+  @Mapping(target = "address", source = "placeItem.place.address")
+  @Mapping(target = "roadAddress", source = "placeItem.place.roadAddress")
+  @Mapping(target = "lat", source = "placeItem.place.lat")
+  @Mapping(target = "lng", source = "placeItem.place.lng")
+  PlaceItemResponse toPlaceItemResponseDto(PlaceItem placeItem);
+}

--- a/src/main/java/com/heylocal/traveler/mapper/PlaceMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/PlaceMapper.java
@@ -3,15 +3,12 @@ package com.heylocal.traveler.mapper;
 import com.heylocal.traveler.domain.Region;
 import com.heylocal.traveler.domain.place.Place;
 import com.heylocal.traveler.domain.plan.list.PlaceItem;
-import com.heylocal.traveler.dto.PlaceDto;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 import static com.heylocal.traveler.dto.PlaceDto.*;
-import static com.heylocal.traveler.dto.PlaceDto.PlaceItemResponse;
-import static com.heylocal.traveler.dto.PlaceDto.PlaceResponse;
 
 @Mapper(uses = {RegionMapper.class}, builder = @Builder(disableBuilder = true))
 public interface PlaceMapper {

--- a/src/main/java/com/heylocal/traveler/mapper/PlanMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/PlanMapper.java
@@ -2,13 +2,13 @@ package com.heylocal.traveler.mapper;
 
 import com.heylocal.traveler.domain.plan.DaySchedule;
 import com.heylocal.traveler.domain.plan.Plan;
-import com.heylocal.traveler.dto.PlanDto;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-import static com.heylocal.traveler.dto.PlanDto.*;
+import static com.heylocal.traveler.dto.PlanDto.PlanPlacesResponse;
+import static com.heylocal.traveler.dto.PlanDto.PlanResponse;
 
 @Mapper(uses = {PlaceMapper.class}, builder = @Builder(disableBuilder = true))
 public interface PlanMapper {

--- a/src/main/java/com/heylocal/traveler/mapper/PlanMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/PlanMapper.java
@@ -1,0 +1,27 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.plan.DaySchedule;
+import com.heylocal.traveler.domain.plan.Plan;
+import com.heylocal.traveler.dto.PlanDto;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.PlanDto.*;
+
+@Mapper(uses = {PlaceMapper.class}, builder = @Builder(disableBuilder = true))
+public interface PlanMapper {
+  PlanMapper INSTANCE = Mappers.getMapper(PlanMapper.class);
+
+  @Mapping(target = "regionId", source = "plan.travelOn.region.id")
+  @Mapping(target = "regionState", source = "plan.travelOn.region.state")
+  @Mapping(target = "regionCity", source = "plan.travelOn.region.city")
+  @Mapping(target = "startDate", source = "plan.travelOn.travelStartDate")
+  @Mapping(target = "endDate", source = "plan.travelOn.travelEndDate")
+  PlanResponse toPlanResponseDto(Plan plan);
+
+  @Mapping(target = "date", source = "daySchedule.dateTime")
+  @Mapping(target = "places", source = "daySchedule.placeItemList")
+  PlanPlacesResponse toPlanPlacesResponseDto(DaySchedule daySchedule);
+}

--- a/src/main/java/com/heylocal/traveler/mapper/RegionMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/RegionMapper.java
@@ -1,0 +1,15 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.Region;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.RegionDto.RegionResponse;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface RegionMapper {
+  RegionMapper INSTANCE = Mappers.getMapper(RegionMapper.class);
+
+  RegionResponse toResponseDto(Region region);
+}

--- a/src/main/java/com/heylocal/traveler/mapper/TravelMemberMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/TravelMemberMapper.java
@@ -1,0 +1,26 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.list.MemberType;
+import com.heylocal.traveler.domain.travelon.list.TravelMember;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.TravelMemberDto.TravelMemberResponse;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface TravelMemberMapper {
+  TravelMemberMapper INSTANCE = Mappers.getMapper(TravelMemberMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "memberType", source = "type")
+  TravelMember toEntity(TravelOn travelOn, MemberType type);
+
+  @Mapping(target = "type", source = "memberType")
+  TravelMemberResponse toResponseDto(TravelMember travelMember);
+
+  @AfterMapping
+  default void registerTravelOnToEntity(TravelOn travelOn, @MappingTarget TravelMember travelMember) {
+    travelMember.registerAt(travelOn);
+  }
+}

--- a/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
@@ -1,0 +1,83 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.Region;
+import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.list.*;
+import com.heylocal.traveler.domain.user.User;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+import java.util.Set;
+
+import static com.heylocal.traveler.dto.TravelOnDto.*;
+import static com.heylocal.traveler.dto.TravelTypeGroupDto.*;
+
+@Mapper(uses = {RegionMapper.class, UserMapper.class, TravelMemberMapper.class, HopeAccommodationMapper.class, HopeDrinkMapper.class, HopeFoodMapper.class, TravelTypeGroupMapper.class},
+    builder = @Builder(disableBuilder = true)
+)
+public interface TravelOnMapper {
+  TravelOnMapper INSTANCE = Mappers.getMapper(TravelOnMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "region", source = "region")
+  @Mapping(target = "author", source = "author")
+  @Mapping(target = "views", constant = "0")
+  @Mapping(target = "opinionList", ignore = true)
+  @Mapping(target = "plan", ignore = true)
+  @Mapping(target = "travelMemberSet", ignore = true)
+  @Mapping(target = "hopeAccommodationSet", ignore = true)
+  @Mapping(target = "hopeFoodSet", ignore = true)
+  @Mapping(target = "hopeDrinkSet", ignore = true)
+  @Mapping(target = "travelTypeGroup", ignore = true)
+  TravelOn toEntity(TravelOnRequest travelOnRequest, User author, Region region);
+
+  @Mapping(target = "createdDateTime", source = "createdDate")
+  @Mapping(target = "modifiedDate", source = "modifiedDate")
+  TravelOnResponse toTravelOnResponseDto(TravelOn travelOn);
+
+  @Mapping(target = "createdDateTime", source = "createdDate")
+  @Mapping(target = "opinionQuantity", expression = "java(travelOn.getOpinionList().size())")
+  TravelOnSimpleResponse toTravelOnSimpleResponseDto(TravelOn travelOn);
+
+  @AfterMapping
+  default void updateEntityHopeDrinkSet(TravelOnRequest travelOnRequest, @MappingTarget TravelOn travelOn) {
+    Set<DrinkType> drinkTypeSet = travelOnRequest.getDrinkTypeSet();
+
+    drinkTypeSet.stream().forEach(
+        (item) -> HopeDrinkMapper.INSTANCE.toEntity(travelOn, item)
+    );
+  }
+
+  @AfterMapping
+  default void updateEntityHopeFoodSet(TravelOnRequest travelOnRequest, @MappingTarget TravelOn travelOn) {
+    Set<FoodType> foodTypeSet = travelOnRequest.getFoodTypeSet();
+
+    foodTypeSet.stream().forEach(
+        (item) -> HopeFoodMapper.INSTANCE.toEntity(travelOn, item)
+    );
+  }
+
+  @AfterMapping
+  default void updateEntityHopeAccommodationSet(TravelOnRequest travelOnRequest, @MappingTarget TravelOn travelOn) {
+    Set<AccommodationType> accommodationTypeSet = travelOnRequest.getAccommodationTypeSet();
+
+    accommodationTypeSet.stream().forEach(
+        (item) -> HopeAccommodationMapper.INSTANCE.toEntity(travelOn, item)
+    );
+  }
+
+  @AfterMapping
+  default void updateEntityTravelMemberSet(TravelOnRequest travelOnRequest, @MappingTarget TravelOn travelOn) {
+    Set<MemberType> memberTypeSet = travelOnRequest.getMemberTypeSet();
+
+    memberTypeSet.stream().forEach(
+        (item) -> TravelMemberMapper.INSTANCE.toEntity(travelOn, item)
+    );
+  }
+
+  @AfterMapping
+  default void updateEntityTravelTypeGroup(TravelOnRequest travelOnRequest, @MappingTarget TravelOn travelOn) {
+    TravelTypeGroupRequest travelTypeGroupRequest = travelOnRequest.getTravelTypeGroup();
+    TravelTypeGroupMapper.INSTANCE.toEntity(travelTypeGroupRequest, travelOn);
+  }
+}

--- a/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
@@ -2,7 +2,10 @@ package com.heylocal.traveler.mapper;
 
 import com.heylocal.traveler.domain.Region;
 import com.heylocal.traveler.domain.travelon.TravelOn;
-import com.heylocal.traveler.domain.travelon.list.*;
+import com.heylocal.traveler.domain.travelon.list.AccommodationType;
+import com.heylocal.traveler.domain.travelon.list.DrinkType;
+import com.heylocal.traveler.domain.travelon.list.FoodType;
+import com.heylocal.traveler.domain.travelon.list.MemberType;
 import com.heylocal.traveler.domain.user.User;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
@@ -10,7 +13,7 @@ import org.mapstruct.factory.Mappers;
 import java.util.Set;
 
 import static com.heylocal.traveler.dto.TravelOnDto.*;
-import static com.heylocal.traveler.dto.TravelTypeGroupDto.*;
+import static com.heylocal.traveler.dto.TravelTypeGroupDto.TravelTypeGroupRequest;
 
 @Mapper(uses = {RegionMapper.class, UserMapper.class, TravelMemberMapper.class, HopeAccommodationMapper.class, HopeDrinkMapper.class, HopeFoodMapper.class, TravelTypeGroupMapper.class},
     builder = @Builder(disableBuilder = true)

--- a/src/main/java/com/heylocal/traveler/mapper/TravelTypeGroupMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/TravelTypeGroupMapper.java
@@ -1,0 +1,29 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.TravelTypeGroup;
+import com.heylocal.traveler.dto.TravelTypeGroupDto;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.TravelTypeGroupDto.*;
+import static com.heylocal.traveler.dto.TravelTypeGroupDto.TravelTypeGroupResponse;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface TravelTypeGroupMapper {
+  TravelTypeGroupMapper INSTANCE = Mappers.getMapper(TravelTypeGroupMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "travelOn", ignore = true)
+  TravelTypeGroup toEntity(TravelTypeGroupRequest travelTypeGroupRequest);
+
+  @Mapping(target = "id", ignore = true)
+  TravelTypeGroup toEntity(TravelTypeGroupRequest travelTypeGroupRequest, TravelOn travelOn);
+
+  TravelTypeGroupResponse toResponseDto(TravelTypeGroup travelTypeGroup);
+
+  @AfterMapping
+  default void registerTravelOnToEntity(TravelOn travelOn, @MappingTarget TravelTypeGroup travelTypeGroup) {
+    travelTypeGroup.registerAt(travelOn);
+  }
+}

--- a/src/main/java/com/heylocal/traveler/mapper/TravelTypeGroupMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/TravelTypeGroupMapper.java
@@ -2,11 +2,10 @@ package com.heylocal.traveler.mapper;
 
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.travelon.TravelTypeGroup;
-import com.heylocal.traveler.dto.TravelTypeGroupDto;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
-import static com.heylocal.traveler.dto.TravelTypeGroupDto.*;
+import static com.heylocal.traveler.dto.TravelTypeGroupDto.TravelTypeGroupRequest;
 import static com.heylocal.traveler.dto.TravelTypeGroupDto.TravelTypeGroupResponse;
 
 @Mapper(builder = @Builder(disableBuilder = true))

--- a/src/main/java/com/heylocal/traveler/mapper/UserMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/UserMapper.java
@@ -7,7 +7,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-import static com.heylocal.traveler.dto.UserDto.*;
+import static com.heylocal.traveler.dto.UserDto.UserProfileResponse;
+import static com.heylocal.traveler.dto.UserDto.UserResponse;
 
 @Mapper(builder = @Builder(disableBuilder = true))
 public interface UserMapper {

--- a/src/main/java/com/heylocal/traveler/mapper/UserMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/UserMapper.java
@@ -1,0 +1,22 @@
+package com.heylocal.traveler.mapper;
+
+import com.heylocal.traveler.domain.profile.UserProfile;
+import com.heylocal.traveler.domain.user.User;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import static com.heylocal.traveler.dto.UserDto.*;
+
+@Mapper(builder = @Builder(disableBuilder = true))
+public interface UserMapper {
+  UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+  @Mapping(target = "nickname", source = "entity.user.nickname")
+  UserProfileResponse toUserProfileResponseDto(UserProfile entity, long ranking);
+
+  @Mapping(target = "imageUrl", source = "user.userProfile.imageUrl")
+  @Mapping(target = "knowHow", source = "user.userProfile.knowHow")
+  UserResponse toUserResponseDto(User user);
+}

--- a/src/main/java/com/heylocal/traveler/service/OpinionService.java
+++ b/src/main/java/com/heylocal/traveler/service/OpinionService.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.heylocal.traveler.dto.OpinionDto.*;
 import static com.heylocal.traveler.dto.OpinionDto.OpinionRequest;
+import static com.heylocal.traveler.dto.OpinionDto.OpinionResponse;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/heylocal/traveler/service/OpinionService.java
+++ b/src/main/java/com/heylocal/traveler/service/OpinionService.java
@@ -12,6 +12,7 @@ import com.heylocal.traveler.exception.ForbiddenException;
 import com.heylocal.traveler.exception.NotFoundException;
 import com.heylocal.traveler.exception.code.ForbiddenCode;
 import com.heylocal.traveler.exception.code.NotFoundCode;
+import com.heylocal.traveler.mapper.OpinionMapper;
 import com.heylocal.traveler.repository.OpinionRepository;
 import com.heylocal.traveler.repository.PlaceRepository;
 import com.heylocal.traveler.repository.TravelOnRepository;
@@ -78,7 +79,7 @@ public class OpinionService {
     requestPlace = inquiryPlaceFromOpinionRequest(request);
 
     //새 답변 추가
-    newOpinion = request.toEntity(requestPlace, opinionAuthor, travelOn, regionOfRequestPlace);
+    newOpinion = OpinionMapper.INSTANCE.toEntity(request, requestPlace, opinionAuthor, travelOn, regionOfRequestPlace);
     opinionRepository.save(newOpinion);
   }
 
@@ -97,7 +98,7 @@ public class OpinionService {
     targetTravelOn = inquiryTravelOn(travelOnId);
 
     //List<Opinion> -> List<OpinionResponse>
-    result = targetTravelOn.getOpinionList().stream().map(OpinionResponse::new).collect(Collectors.toList());
+    result = targetTravelOn.getOpinionList().stream().map(OpinionMapper.INSTANCE::toResponseDto).collect(Collectors.toList());
 
     return result;
   }

--- a/src/main/java/com/heylocal/traveler/service/PlanService.java
+++ b/src/main/java/com/heylocal/traveler/service/PlanService.java
@@ -1,6 +1,5 @@
 package com.heylocal.traveler.service;
 
-import com.heylocal.traveler.domain.Region;
 import com.heylocal.traveler.domain.place.Place;
 import com.heylocal.traveler.domain.plan.DaySchedule;
 import com.heylocal.traveler.domain.plan.Plan;
@@ -15,13 +14,13 @@ import com.heylocal.traveler.exception.code.ForbiddenCode;
 import com.heylocal.traveler.exception.code.NotFoundCode;
 import com.heylocal.traveler.repository.PlaceItemRepository;
 import com.heylocal.traveler.repository.PlaceRepository;
+import com.heylocal.traveler.mapper.PlanMapper;
 import com.heylocal.traveler.repository.PlanRepository;
 import com.heylocal.traveler.repository.TravelOnRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.text.html.Option;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -58,7 +57,7 @@ public class PlanService {
 
 		// Plan -> PlanResponse 변환
 		List<PlanResponse> planResponses = plans.stream()
-				.map(PlanResponse::new)
+				.map(PlanMapper.INSTANCE::toPlanResponseDto)
 				.collect(Collectors.toList());
 
 		// 플랜을 날짜에 따라 분류
@@ -185,7 +184,7 @@ public class PlanService {
 		// List<DaySchedule> -> List<PlanPlacesReponse>
 		List<DaySchedule> daySchedules = plan.getDayScheduleList();
 		return daySchedules.stream()
-				.map(PlanPlacesResponse::new)
+				.map(PlanMapper.INSTANCE::toPlanPlacesResponseDto)
 				.collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/heylocal/traveler/service/RegionService.java
+++ b/src/main/java/com/heylocal/traveler/service/RegionService.java
@@ -5,6 +5,7 @@ import com.heylocal.traveler.exception.BadRequestException;
 import com.heylocal.traveler.exception.NotFoundException;
 import com.heylocal.traveler.exception.code.BadRequestCode;
 import com.heylocal.traveler.exception.code.NotFoundCode;
+import com.heylocal.traveler.mapper.RegionMapper;
 import com.heylocal.traveler.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,7 +36,7 @@ public class RegionService {
     if (regionList.size() == 0) {
       throw new NotFoundException(NotFoundCode.NO_INFO, "해당 state가 존재하지 않습니다.");
     }
-    result = regionList.stream().map(RegionResponse::new).collect(Collectors.toList());
+    result = regionList.stream().map(RegionMapper.INSTANCE::toResponseDto).collect(Collectors.toList());
 
 
     return result;

--- a/src/main/java/com/heylocal/traveler/service/TravelOnService.java
+++ b/src/main/java/com/heylocal/traveler/service/TravelOnService.java
@@ -13,6 +13,8 @@ import com.heylocal.traveler.exception.ForbiddenException;
 import com.heylocal.traveler.exception.NotFoundException;
 import com.heylocal.traveler.exception.code.ForbiddenCode;
 import com.heylocal.traveler.exception.code.NotFoundCode;
+import com.heylocal.traveler.mapper.TravelOnMapper;
+import com.heylocal.traveler.mapper.TravelTypeGroupMapper;
 import com.heylocal.traveler.repository.RegionRepository;
 import com.heylocal.traveler.repository.TravelOnRepository;
 import com.heylocal.traveler.repository.UserRepository;
@@ -26,6 +28,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.heylocal.traveler.dto.TravelOnDto.*;
+import static com.heylocal.traveler.dto.TravelTypeGroupDto.*;
 
 @Slf4j
 @Service
@@ -52,7 +55,7 @@ public class TravelOnService {
     region = regionRepository.findById(request.getRegionId()).orElseThrow(
         () -> new NotFoundException(NotFoundCode.NO_INFO, "존재하지 않는 Region ID 입니다.")
     );
-    travelOn = request.toEntity(author, region);
+    travelOn = TravelOnMapper.INSTANCE.toEntity(request, author, region);
     travelOnRepository.saveTravelOn(travelOn);
   }
 
@@ -77,7 +80,7 @@ public class TravelOnService {
 
     //List<TravelOn> -> List<TravelOnSimpleResponse>
     response = travelOnList.stream()
-        .map(TravelOnSimpleResponse::new)
+        .map(TravelOnMapper.INSTANCE::toTravelOnSimpleResponseDto)
         .collect(Collectors.toList());
 
     return response;
@@ -97,7 +100,7 @@ public class TravelOnService {
     travelOn = travelOnRepository.findById(travelOnId).orElseThrow(
         () -> new NotFoundException(NotFoundCode.NO_INFO, "존재하지 않는 여행On ID 입니다.")
     );
-    response = new TravelOnResponse(travelOn);
+    response = TravelOnMapper.INSTANCE.toTravelOnResponseDto(travelOn);
 
     return response;
   }
@@ -179,7 +182,8 @@ public class TravelOnService {
   }
 
   private void updateTravelTypeGroup(TravelOnRequest request, TravelOn originTravelOn) {
-    TravelTypeGroup travelTypeGroup = request.getTravelTypeGroup().toEntity();
+    TravelTypeGroupRequest travelTypeGroupRequest = request.getTravelTypeGroup();
+    TravelTypeGroup travelTypeGroup = TravelTypeGroupMapper.INSTANCE.toEntity(travelTypeGroupRequest);
     travelTypeGroup.registerAt(originTravelOn);
     originTravelOn.updateTravelTypeGroup(travelTypeGroup);
   }

--- a/src/main/java/com/heylocal/traveler/service/TravelOnService.java
+++ b/src/main/java/com/heylocal/traveler/service/TravelOnService.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.heylocal.traveler.dto.TravelOnDto.*;
-import static com.heylocal.traveler.dto.TravelTypeGroupDto.*;
+import static com.heylocal.traveler.dto.TravelTypeGroupDto.TravelTypeGroupRequest;
 
 @Slf4j
 @Service

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/Entity.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/Entity.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Entity {
+  private Long id;
+  private String fieldA;
+  private String fieldB;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructTest.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructTest.java
@@ -15,7 +15,6 @@ import com.heylocal.traveler.code.mapstruct.expression.ExpressionMapper;
 import com.heylocal.traveler.code.mapstruct.inherit.InheritMapper;
 import com.heylocal.traveler.code.mapstruct.inherit.MyDto;
 import com.heylocal.traveler.code.mapstruct.inherit.MyEntity;
-import com.heylocal.traveler.code.mapstruct.inherit.NoInheritMapper;
 import com.heylocal.traveler.code.mapstruct.multi.MultiEntityDto;
 import com.heylocal.traveler.code.mapstruct.multi.MultiEntityMapper;
 import com.heylocal.traveler.code.mapstruct.multi.OtherEntity;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructTest.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructTest.java
@@ -1,0 +1,358 @@
+package com.heylocal.traveler.code.mapstruct;
+
+import com.heylocal.traveler.code.mapstruct.basic.BasicDto;
+import com.heylocal.traveler.code.mapstruct.basic.BasicMapper;
+import com.heylocal.traveler.code.mapstruct.defaultmethod.DefaultMethodMapper;
+import com.heylocal.traveler.code.mapstruct.defaultvalue.DefaultValueMapper;
+import com.heylocal.traveler.code.mapstruct.dependent.*;
+import com.heylocal.traveler.code.mapstruct.difffield.DiffFieldNameDto;
+import com.heylocal.traveler.code.mapstruct.difffield.DiffFieldNameMapper;
+import com.heylocal.traveler.code.mapstruct.enums.DetailFruitType;
+import com.heylocal.traveler.code.mapstruct.enums.EnumMapper;
+import com.heylocal.traveler.code.mapstruct.enums.GeneralFruitType;
+import com.heylocal.traveler.code.mapstruct.exception.ExceptionMapper;
+import com.heylocal.traveler.code.mapstruct.expression.ExpressionMapper;
+import com.heylocal.traveler.code.mapstruct.inherit.InheritMapper;
+import com.heylocal.traveler.code.mapstruct.inherit.MyDto;
+import com.heylocal.traveler.code.mapstruct.inherit.MyEntity;
+import com.heylocal.traveler.code.mapstruct.inherit.NoInheritMapper;
+import com.heylocal.traveler.code.mapstruct.multi.MultiEntityDto;
+import com.heylocal.traveler.code.mapstruct.multi.MultiEntityMapper;
+import com.heylocal.traveler.code.mapstruct.multi.OtherEntity;
+import com.heylocal.traveler.code.mapstruct.type.LocalDateDto;
+import com.heylocal.traveler.code.mapstruct.type.LocalDateEntity;
+import com.heylocal.traveler.code.mapstruct.type.LocalDateMapper;
+import com.heylocal.traveler.code.mapstruct.update.EntityUpdateMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+public class MapStructTest {
+
+  @Test
+  @DisplayName("기본 매퍼 사용")
+  void useBasicMapper() {
+    //GIVEN
+    Entity entity = new Entity(1L, "fieldA Value", "fieldB Value");
+
+    //WHEN
+    BasicDto dto = BasicMapper.INSTANCE.toDto(entity);
+
+    //THEN
+    assertAll(
+        () -> assertSame(entity.getId(), dto.getId()),
+        () -> assertEquals(entity.getFieldA(), dto.getFieldA()),
+        () -> assertEquals(entity.getFieldB(), dto.getFieldB())
+    );
+  }
+
+  @Test
+  @DisplayName("DTO 와 엔티티의 필드명이 다른 경우")
+  void differentFieldName() {
+    //GIVEN
+    Entity entity = new Entity(1L, "fieldA Value", "fieldB Value");
+
+    //WHEN
+    DiffFieldNameDto dto = DiffFieldNameMapper.INSTANCE.toDto(entity);
+
+    //THEN
+    assertAll(
+        () -> assertSame(entity.getId(), dto.getId()),
+        () -> assertEquals(entity.getFieldA(), dto.getNewFieldA()),
+        () -> assertEquals(entity.getFieldB(), dto.getNewFieldB())
+    );
+  }
+
+  @Test
+  @DisplayName("한 DTO에 여러 엔티티를 매핑하는 경우")
+  void multiEntity() {
+    //GIVEN
+    Entity entityA = new Entity(1L, "entityA.fieldA Value", "entityA.fieldB Value");
+    OtherEntity entityB = new OtherEntity(1L, "entityB.fieldA Value", "entityB.fieldB Value");
+
+    //WHEN
+    MultiEntityDto dto = MultiEntityMapper.INSTANCE.toDto(entityA, entityB);
+
+    //THEN
+    assertAll(
+        () -> assertEquals(entityA.getFieldA(), dto.getFieldA()),
+        () -> assertEquals(entityA.getFieldB(), dto.getFieldB()),
+        () -> assertEquals(entityB.getFieldA(), dto.getOtherFieldA()),
+        () -> assertEquals(entityB.getFieldB(), dto.getOtherFieldB())
+    );
+  }
+
+  @Test
+  @DisplayName("다른 엔티티를 의존하는 엔티티를 매핑하는 경우")
+  void dependentEntity() {
+    //GIVEN
+    Entity entityA = new Entity(1L, "entityA.fieldA Value", "entityA.fieldB Value");
+    OtherEntity entityB1 = new OtherEntity(1L, "entityB1.fieldA Value", "entityB1.fieldB Value");
+    OtherEntity entityB2 = new OtherEntity(2L, "entityB2.fieldA Value", "entityB2.fieldB Value");
+    List<OtherEntity> otherEntityList = new ArrayList<>();
+    otherEntityList.add(entityB1);
+    otherEntityList.add(entityB2);
+
+    DependentOtherEntity dependentOtherEntity = new DependentOtherEntity(
+        1L,
+        "dependentOtherEntity.fieldA Value",
+        entityA,
+        otherEntityList
+    );
+
+    //WHEN
+    DependentOtherDto dto = DependentOtherMapper.INSTANCE.toDto(dependentOtherEntity);
+    EntityDto entityADto = dto.getEntityDto();
+    List<OtherEntityDto> entityBDtoList = dto.getOtherEntityDtoList();
+    OtherEntityDto entityB1Dto = entityBDtoList.get(0);
+    OtherEntityDto entityB2Dto = entityBDtoList.get(1);
+
+    //THEN
+    assertAll(
+        () -> assertEquals(entityA.getFieldA(), entityADto.getFieldA()),
+        () -> assertEquals(entityA.getFieldB(), entityADto.getFieldB()),
+        () -> assertEquals(entityB1.getFieldA(), entityB1Dto.getFieldA()),
+        () -> assertEquals(entityB1.getFieldB(), entityB1Dto.getFieldB()),
+        () -> assertEquals(entityB2.getFieldA(), entityB2Dto.getFieldA()),
+        () -> assertEquals(entityB2.getFieldB(), entityB2Dto.getFieldB())
+    );
+  }
+
+  @Test
+  @DisplayName("기존 엔티티 업데이트")
+  void updateEntity() {
+    //GIVEN
+    /* 기존 엔티티 */
+    DependentOtherEntity existedEntity = new DependentOtherEntity(
+        1L,
+        "old fieldA Value",
+        new Entity(1L, "", ""),
+        new ArrayList<>()
+    );
+
+    List<OtherEntityDto> otherEntityList = new ArrayList<>();
+    otherEntityList.add(new OtherEntityDto(1L, "new value", "new value"));
+    otherEntityList.add(new OtherEntityDto(2L, "new value", "new value"));
+    /* 새로운 데이터(DTO) */
+    DependentOtherDto newDto = new DependentOtherDto(
+        "new fieldA value",
+        new EntityDto(5L, "new value", "new value"),
+        otherEntityList
+    );
+
+    //WHEN
+    EntityUpdateMapper.INSTANCE.updateEntity(newDto, existedEntity);
+
+    //THEN
+    assertAll(
+        () -> assertEquals(newDto.getFieldA(), existedEntity.getFieldA()),
+        () -> assertEquals(newDto.getEntityDto().getId(), existedEntity.getEntity().getId()),
+        () -> assertSame(2, existedEntity.getOtherEntityList().size())
+    );
+  }
+
+  @Test
+  @DisplayName("Enum 간 매핑 - 첫번째 방법")
+  void enumMapping1() {
+    //GIVEN
+    DetailFruitType orangeDetailType = DetailFruitType.ORANGE;
+    DetailFruitType bananaDetailType = DetailFruitType.BANANA;
+    DetailFruitType redAppleDetailType = DetailFruitType.RED_APPLE;
+    DetailFruitType yellowAppleDetailType = DetailFruitType.YELLOW_APPLE;
+    DetailFruitType greenAppleDetailType = DetailFruitType.GREEN_APPLE;
+
+    //WHEN
+    GeneralFruitType orangeResult = EnumMapper.INSTANCE.toFruitType1(orangeDetailType);
+    GeneralFruitType bananaResult = EnumMapper.INSTANCE.toFruitType1(bananaDetailType);
+    GeneralFruitType redAppleResult = EnumMapper.INSTANCE.toFruitType1(redAppleDetailType);
+    GeneralFruitType yellowAppleResult = EnumMapper.INSTANCE.toFruitType1(yellowAppleDetailType);
+    GeneralFruitType greenAppleResult = EnumMapper.INSTANCE.toFruitType1(greenAppleDetailType);
+
+    //THEN
+    assertAll(
+        () -> assertSame(GeneralFruitType.ORANGE, orangeResult),
+        () -> assertSame(GeneralFruitType.BANANA, bananaResult),
+        () -> assertSame(GeneralFruitType.APPLE, redAppleResult),
+        () -> assertSame(GeneralFruitType.APPLE, yellowAppleResult),
+        () -> assertSame(GeneralFruitType.APPLE, greenAppleResult)
+    );
+  }
+
+  @Test
+  @DisplayName("Enum 간 매핑 - 두번째 방법")
+  void enumMapping2() {
+    //GIVEN
+    DetailFruitType orangeDetailType = DetailFruitType.ORANGE;
+    DetailFruitType bananaDetailType = DetailFruitType.BANANA;
+    DetailFruitType redAppleDetailType = DetailFruitType.RED_APPLE;
+    DetailFruitType yellowAppleDetailType = DetailFruitType.YELLOW_APPLE;
+    DetailFruitType greenAppleDetailType = DetailFruitType.GREEN_APPLE;
+
+    //WHEN
+    GeneralFruitType orangeResult = EnumMapper.INSTANCE.toFruitType2(orangeDetailType);
+    GeneralFruitType bananaResult = EnumMapper.INSTANCE.toFruitType2(bananaDetailType);
+    GeneralFruitType redAppleResult = EnumMapper.INSTANCE.toFruitType2(redAppleDetailType);
+    GeneralFruitType yellowAppleResult = EnumMapper.INSTANCE.toFruitType2(yellowAppleDetailType);
+    GeneralFruitType greenAppleResult = EnumMapper.INSTANCE.toFruitType2(greenAppleDetailType);
+
+    //THEN
+    assertAll(
+        () -> assertSame(GeneralFruitType.ORANGE, orangeResult),
+        () -> assertSame(GeneralFruitType.BANANA, bananaResult),
+        () -> assertSame(GeneralFruitType.APPLE, redAppleResult),
+        () -> assertSame(GeneralFruitType.APPLE, yellowAppleResult),
+        () -> assertSame(GeneralFruitType.APPLE, greenAppleResult)
+    );
+  }
+
+  @Test
+  @DisplayName("LocalDate 값을 String 타입에 매핑")
+  void localDateMapper() {
+    //GIVEN
+    LocalDateEntity entity = new LocalDateEntity(1L, LocalDate.now());
+
+    //WHEN
+    LocalDateDto dto = LocalDateMapper.INSTANCE.toDto(entity);
+    boolean matchResult = Pattern.matches("^[0-9]{4}/[0-9]{2}/[0-9]{2}$", dto.getDate());
+
+    //THEN
+    assertAll(
+        () -> assertSame(entity.getId(), dto.getId()),
+        () -> assertTrue(matchResult)
+    );
+  }
+
+  @Test
+  @DisplayName("default method 를 통한 매핑 메서드 직접 구현")
+  void defaultMethodMapper() {
+    //GIVEN
+    Entity entity = new Entity(1L, "valueA", "valueB");
+
+    //WHEN
+    EntityDto basicDto = DefaultMethodMapper.INSTANCE.basicToDto(entity);
+    EntityDto specialDto = DefaultMethodMapper.INSTANCE.specialToDto(entity);
+
+    //THEN
+    assertAll(
+        () -> assertSame(entity.getId(), basicDto.getId()),
+        () -> assertEquals(entity.getFieldA(), basicDto.getFieldA()),
+        () -> assertEquals(entity.getFieldB(), basicDto.getFieldB()),
+        () -> assertSame(entity.getId(), basicDto.getId()),
+        () -> assertEquals("Special Value of A!!!", specialDto.getFieldA()),
+        () -> assertEquals("Special Value of B!!!", specialDto.getFieldB())
+    );
+  }
+
+  @Test
+  @DisplayName("필드에 기본값 매핑")
+  void abstractMapper() {
+    //GIVEN
+    Entity entity = new Entity(10L, null, null);
+
+    //WHEN
+    EntityDto dto = DefaultValueMapper.INSTANCE.toDto(entity);
+
+    //THEN
+    assertAll(
+        () -> assertSame(-1L, dto.getId()),
+        () -> assertEquals("empty value", dto.getFieldA()),
+        () -> assertNull(dto.getFieldB())
+    );
+  }
+
+  @Test
+  @DisplayName("자바 표현식으로 매핑")
+  void expressionMapper() {
+    //GIVEN
+    Entity entity = new Entity(10L, null, "fieldB value");
+
+    //WHEN
+    EntityDto dto = ExpressionMapper.INSTANCE.toDto(entity);
+    log.info("dto.id = {}", dto.getId());
+    log.info("dto.fieldA = {}", dto.getFieldA());
+    log.info("dto.fieldB = {}", dto.getFieldB());
+
+    //THEN
+    assertAll(
+        () -> assertNotSame(entity.getId(), dto.getId()),
+        () -> assertNotNull(dto.getFieldA()),
+        () -> assertEquals("fieldB value", dto.getFieldB())
+    );
+  }
+
+  @Test
+  @DisplayName("예외처리와 함께 매핑")
+  void exceptionMapper() {
+    //GIVEN
+    Entity invalidIdEntity = new Entity(-10L, "fieldA value", "fieldB value");
+    Entity invalidFieldEntity1 = new Entity(1L, "", "fieldB value");
+    Entity invalidFieldEntity2 = new Entity(1L, "fieldA value", "");
+    Entity validEntity = new Entity(1L, "fieldA value", "fieldB value");
+
+    //WHEN
+    //ExceptionMapper.INSTANCE.toDto(invalidIdEntity);
+    //ExceptionMapper.INSTANCE.toDto(invalidFieldEntity1);
+    //ExceptionMapper.INSTANCE.toDto(invalidFieldEntity2)
+    ExceptionMapper.INSTANCE.toDto(validEntity);
+
+    //THEN
+    assertAll(
+        () -> assertThrows(
+            IllegalArgumentException.class,
+            () -> ExceptionMapper.INSTANCE.toDto(invalidIdEntity)
+        ),
+        () -> assertThrows(
+            IllegalArgumentException.class,
+            () -> ExceptionMapper.INSTANCE.toDto(invalidFieldEntity1)
+        ),
+        () -> assertThrows(
+            IllegalArgumentException.class,
+            () -> ExceptionMapper.INSTANCE.toDto(invalidFieldEntity2)
+        ),
+        () -> assertDoesNotThrow(
+            () -> ExceptionMapper.INSTANCE.toDto(validEntity)
+        )
+    );
+  }
+
+  @Test
+  @DisplayName("@InheritConfiguration 을 통한 매핑설정 상속")
+  void inheritConfiguration() {
+    //GIVEN
+    MyDto dto = new MyDto(1L, 1, 1);
+
+    //WHEN
+    MyEntity entity = InheritMapper.INSTANCE.toEntity(dto);
+    dto.setId(10L);
+    InheritMapper.INSTANCE.updateEntity(dto, entity);
+
+    //THEN
+    assertSame(dto.getId(), entity.getId());
+  }
+
+  @Test
+  @DisplayName("@InheritInverseConfiguration 을 통한 매핑설정 상속")
+  void inheritInverseConfiguration() {
+    //GIVEN
+    MyEntity entity = new MyEntity(1L, 1, 1);
+
+    //WHEN
+    MyDto dto = InheritMapper.INSTANCE.toDto(entity);
+
+    //THEN
+    assertAll(
+        () -> assertSame(dto.getId(), entity.getId()),
+        () -> assertSame(dto.getNewMyFieldA(), entity.getMyFieldA()),
+        () -> assertSame(dto.getNewMyFieldB(), entity.getMyFieldB())
+    );
+  }
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructWithSpringTest.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructWithSpringTest.java
@@ -2,7 +2,6 @@ package com.heylocal.traveler.code.mapstruct;
 
 import com.heylocal.traveler.code.mapstruct.bean.BeanMapper;
 import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
-import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructWithSpringTest.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/MapStructWithSpringTest.java
@@ -1,0 +1,36 @@
+package com.heylocal.traveler.code.mapstruct;
+
+import com.heylocal.traveler.code.mapstruct.bean.BeanMapper;
+import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class MapStructWithSpringTest {
+
+  //MapperImpl 구체 클래스를 DI 컨테이너로부터 주입받는다.
+  @Autowired
+  private BeanMapper beanMapper;
+
+  @Test
+  @DisplayName("Spring Bean 으로 등록된 매퍼 사용")
+  void useBasicMapper() {
+    //GIVEN
+    Entity entity = new Entity(1L, "fieldA Value", "fieldB Value");
+
+    //WHEN
+    EntityDto dto = beanMapper.toDto(entity);
+
+    //THEN
+    assertAll(
+        () -> assertSame(entity.getId(), dto.getId()),
+        () -> assertEquals(entity.getFieldA(), dto.getFieldA()),
+        () -> assertEquals(entity.getFieldB(), dto.getFieldB())
+    );
+  }
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/abstractmapper/AbstractMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/abstractmapper/AbstractMapper.java
@@ -1,0 +1,24 @@
+package com.heylocal.traveler.code.mapstruct.abstractmapper;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
+import org.mapstruct.Mapper;
+
+@Mapper
+public abstract class AbstractMapper {
+
+  //기존 DefaultMethodMapper 인터페이스의 메서드와 동일
+  public abstract EntityDto basicToDto(Entity entity);
+
+  //기존 DefaultMethodMapper 인터페이스의 default 메서드와 동일
+  public EntityDto specialToDto(Entity entity) {
+    EntityDto dto = new EntityDto();
+
+    dto.setId(entity.getId());
+    dto.setFieldA("Special Value of A!!!");
+    dto.setFieldB("Special Value of B!!!");
+
+    return dto;
+  }
+
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/basic/BasicDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/basic/BasicDto.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.basic;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BasicDto {
+  private long id;
+  private String fieldA;
+  private String fieldB;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/basic/BasicMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/basic/BasicMapper.java
@@ -1,0 +1,12 @@
+package com.heylocal.traveler.code.mapstruct.basic;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface BasicMapper {
+  BasicMapper INSTANCE = Mappers.getMapper(BasicMapper.class);
+
+  BasicDto toDto(Entity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/bean/BeanMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/bean/BeanMapper.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.bean;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface BeanMapper {
+  /*
+   * 아래 코드는 더이상 필요없다.
+   * BeanMapper INSTANCE = Mappers.getMapper(BeanMapper.class);
+   */
+
+  EntityDto toDto(Entity entity);
+
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/defaultmethod/DefaultMethodMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/defaultmethod/DefaultMethodMapper.java
@@ -1,0 +1,25 @@
+package com.heylocal.traveler.code.mapstruct.defaultmethod;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface DefaultMethodMapper {
+  DefaultMethodMapper INSTANCE = Mappers.getMapper(DefaultMethodMapper.class);
+
+  //MapStruct 에서 생성해주는 매핑 메서드
+  EntityDto basicToDto(Entity entity);
+
+  //직접 작성한 매핑 메서드
+  default EntityDto specialToDto(Entity entity) {
+    EntityDto dto = new EntityDto();
+
+    dto.setId(entity.getId());
+    dto.setFieldA("Special Value of A!!!");
+    dto.setFieldB("Special Value of B!!!");
+
+    return dto;
+  }
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/defaultvalue/DefaultValueMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/defaultvalue/DefaultValueMapper.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.defaultvalue;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface DefaultValueMapper {
+  DefaultValueMapper INSTANCE = Mappers.getMapper(DefaultValueMapper.class);
+
+  @Mapping(target = "id", constant = "-1L")
+  @Mapping(target = "fieldA", defaultValue = "empty value")
+  EntityDto toDto(Entity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/DependentOtherDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/DependentOtherDto.java
@@ -1,0 +1,18 @@
+package com.heylocal.traveler.code.mapstruct.dependent;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DependentOtherDto {
+  private String fieldA;
+  private EntityDto entityDto;
+  private List<OtherEntityDto> otherEntityDtoList;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/DependentOtherEntity.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/DependentOtherEntity.java
@@ -1,0 +1,21 @@
+package com.heylocal.traveler.code.mapstruct.dependent;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import com.heylocal.traveler.code.mapstruct.multi.OtherEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DependentOtherEntity {
+  private Long id;
+  private String fieldA;
+  private Entity entity; //ManyToOne 관계
+  private List<OtherEntity> otherEntityList; //OneToMany 관계
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/DependentOtherMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/DependentOtherMapper.java
@@ -1,0 +1,14 @@
+package com.heylocal.traveler.code.mapstruct.dependent;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = {EntityMapper.class, OtherEntityMapper.class})
+public interface DependentOtherMapper {
+  DependentOtherMapper INSTANCE = Mappers.getMapper(DependentOtherMapper.class);
+
+  @Mapping(target = "entityDto", source = "dependentEntity.entity")
+  @Mapping(target = "otherEntityDtoList", source = "dependentEntity.otherEntityList")
+  DependentOtherDto toDto(DependentOtherEntity dependentEntity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/EntityDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/EntityDto.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.dependent;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EntityDto {
+  private long id;
+  private String fieldA;
+  private String fieldB;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/EntityMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/EntityMapper.java
@@ -1,0 +1,12 @@
+package com.heylocal.traveler.code.mapstruct.dependent;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface EntityMapper {
+  EntityMapper INSTANCE = Mappers.getMapper(EntityMapper.class);
+
+  EntityDto toDto(Entity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/OtherEntityDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/OtherEntityDto.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.dependent;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtherEntityDto {
+  private long id;
+  private String fieldA;
+  private String fieldB;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/OtherEntityMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/dependent/OtherEntityMapper.java
@@ -1,0 +1,12 @@
+package com.heylocal.traveler.code.mapstruct.dependent;
+
+import com.heylocal.traveler.code.mapstruct.multi.OtherEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface OtherEntityMapper {
+  OtherEntityMapper INSTANCE = Mappers.getMapper(OtherEntityMapper.class);
+
+  OtherEntityDto toDto(OtherEntity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/difffield/DiffFieldNameDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/difffield/DiffFieldNameDto.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.difffield;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiffFieldNameDto {
+  private long id;
+  private String newFieldA;
+  private String newFieldB;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/difffield/DiffFieldNameMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/difffield/DiffFieldNameMapper.java
@@ -1,0 +1,15 @@
+package com.heylocal.traveler.code.mapstruct.difffield;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface DiffFieldNameMapper {
+  DiffFieldNameMapper INSTANCE = Mappers.getMapper(DiffFieldNameMapper.class);
+
+  @Mapping(target = "newFieldA", source = "fieldA")
+  @Mapping(target = "newFieldB", source = "fieldB")
+  DiffFieldNameDto toDto(Entity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/enums/DetailFruitType.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/enums/DetailFruitType.java
@@ -1,0 +1,11 @@
+package com.heylocal.traveler.code.mapstruct.enums;
+
+public enum DetailFruitType {
+  ORANGE,
+  BANANA,
+
+  //사과 종류가 GeneralFruitType 보다 많다.
+  RED_APPLE,
+  YELLOW_APPLE,
+  GREEN_APPLE,
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/enums/EnumMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/enums/EnumMapper.java
@@ -1,0 +1,21 @@
+package com.heylocal.traveler.code.mapstruct.enums;
+
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface EnumMapper {
+  EnumMapper INSTANCE = Mappers.getMapper(EnumMapper.class);
+
+  //매핑하는 첫번째 방법
+  @ValueMappings({
+      @ValueMapping(target = "APPLE", source = "RED_APPLE"),
+      @ValueMapping(target = "APPLE", source = "YELLOW_APPLE"),
+      @ValueMapping(target = "APPLE", source = "GREEN_APPLE")
+  })
+  GeneralFruitType toFruitType1(DetailFruitType detailFruitType);
+
+  //매핑하는 두번째 방법
+  @ValueMapping(target = "APPLE", source = MappingConstants.ANY_REMAINING)
+  GeneralFruitType toFruitType2(DetailFruitType detailFruitType);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/enums/EnumMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/enums/EnumMapper.java
@@ -1,6 +1,9 @@
 package com.heylocal.traveler.code.mapstruct.enums;
 
-import org.mapstruct.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
 import org.mapstruct.factory.Mappers;
 
 @Mapper

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/enums/GeneralFruitType.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/enums/GeneralFruitType.java
@@ -1,0 +1,7 @@
+package com.heylocal.traveler.code.mapstruct.enums;
+
+public enum GeneralFruitType {
+  ORANGE,
+  BANANA,
+  APPLE
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/exception/ExceptionMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/exception/ExceptionMapper.java
@@ -1,0 +1,13 @@
+package com.heylocal.traveler.code.mapstruct.exception;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = Validator.class)
+public interface ExceptionMapper {
+  ExceptionMapper INSTANCE = Mappers.getMapper(ExceptionMapper.class);
+
+  EntityDto toDto(Entity entity) throws IllegalArgumentException;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/exception/Validator.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/exception/Validator.java
@@ -1,0 +1,19 @@
+package com.heylocal.traveler.code.mapstruct.exception;
+
+public class Validator {
+
+  public long validate1(Long id) {
+    if (id < 0) {
+      throw new IllegalArgumentException();
+    }
+    return id;
+  }
+
+  public String validate2(String field) {
+    if (field == null || field.length() == 0) {
+      throw new IllegalArgumentException();
+    }
+    return field;
+  }
+
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/expression/ExpressionMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/expression/ExpressionMapper.java
@@ -1,0 +1,19 @@
+package com.heylocal.traveler.code.mapstruct.expression;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import com.heylocal.traveler.code.mapstruct.dependent.EntityDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Mapper(imports = {LocalDateTime.class, UUID.class})
+public interface ExpressionMapper {
+  ExpressionMapper INSTANCE = Mappers.getMapper(ExpressionMapper.class);
+
+  @Mapping(target = "id", expression = "java(UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE)")
+  @Mapping(target = "fieldA", defaultExpression = "java(LocalDateTime.now().toString())")
+  EntityDto toDto(Entity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/InheritMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/InheritMapper.java
@@ -1,0 +1,21 @@
+package com.heylocal.traveler.code.mapstruct.inherit;
+
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface InheritMapper {
+  InheritMapper INSTANCE = Mappers.getMapper(InheritMapper.class);
+
+  @Mapping(target = "myFieldA", source = "newMyFieldA")
+  @Mapping(target = "myFieldB", source = "newMyFieldB")
+  MyEntity toEntity(MyDto dto);
+
+  //toEntity() 메서드의 @Mapping 설정을 그대로 가져온다.
+  @InheritConfiguration(name = "toEntity")
+  void updateEntity(MyDto dto, @MappingTarget MyEntity entity);
+
+  //toEntity() 메서드의 @Mapping 설정에서 target과 source를 뒤바꿔 가져온다.
+  @InheritInverseConfiguration(name = "toEntity")
+  MyDto toDto(MyEntity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/MyDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/MyDto.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.inherit;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyDto {
+  private long id;
+  private int newMyFieldA; //MyEntity의 myFieldA 와 매핑되어야 함.
+  private int newMyFieldB; //MyEntity의 myFieldB 와 매핑되어야 함.
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/MyEntity.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/MyEntity.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.inherit;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyEntity {
+  private Long id;
+  private int myFieldA;
+  private int myFieldB;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/NoInheritMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/inherit/NoInheritMapper.java
@@ -1,0 +1,24 @@
+package com.heylocal.traveler.code.mapstruct.inherit;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface NoInheritMapper {
+  NoInheritMapper INSTANCE = Mappers.getMapper(NoInheritMapper.class);
+
+  @Mapping(target = "myFieldA", source = "newMyFieldA")
+  @Mapping(target = "myFieldB", source = "newMyFieldB")
+  MyEntity toEntity(MyDto dto);
+
+  //MtDto 값으로 MyEntity 업데이트
+  @Mapping(target = "myFieldA", source = "newMyFieldA")
+  @Mapping(target = "myFieldB", source = "newMyFieldB")
+  void updateEntity(MyDto dto, @MappingTarget MyEntity entity);
+
+  @Mapping(target = "newMyFieldA", source = "myFieldA")
+  @Mapping(target = "newMyFieldB", source = "myFieldB")
+  MyDto toDto(MyEntity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/multi/MultiEntityDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/multi/MultiEntityDto.java
@@ -1,0 +1,17 @@
+package com.heylocal.traveler.code.mapstruct.multi;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MultiEntityDto {
+  private String fieldA; //Entity 클래스의 fieldA 와 매핑
+  private String fieldB; //Entity 클래스의 fieldB 와 매핑
+  private String otherFieldA; //OtherEntity 클래스의 fieldA 와 매핑
+  private String otherFieldB; //OtherEntity 클래스의 fieldB 와 매핑
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/multi/MultiEntityMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/multi/MultiEntityMapper.java
@@ -1,0 +1,17 @@
+package com.heylocal.traveler.code.mapstruct.multi;
+
+import com.heylocal.traveler.code.mapstruct.Entity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface MultiEntityMapper {
+  MultiEntityMapper INSTANCE = Mappers.getMapper(MultiEntityMapper.class);
+
+  @Mapping(target = "fieldA", source = "entityA.fieldA")
+  @Mapping(target = "fieldB", source = "entityA.fieldB")
+  @Mapping(target = "otherFieldA", source = "entityB.fieldA")
+  @Mapping(target = "otherFieldB", source = "entityB.fieldB")
+  MultiEntityDto toDto(Entity entityA, OtherEntity entityB);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/multi/OtherEntity.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/multi/OtherEntity.java
@@ -1,0 +1,16 @@
+package com.heylocal.traveler.code.mapstruct.multi;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtherEntity {
+  private Long id;
+  private String fieldA;
+  private String fieldB;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/type/LocalDateDto.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/type/LocalDateDto.java
@@ -1,0 +1,15 @@
+package com.heylocal.traveler.code.mapstruct.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocalDateDto {
+  private long id;
+  private String date;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/type/LocalDateEntity.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/type/LocalDateEntity.java
@@ -1,0 +1,17 @@
+package com.heylocal.traveler.code.mapstruct.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocalDateEntity {
+  private Long id;
+  private LocalDate localDate;
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/type/LocalDateMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/type/LocalDateMapper.java
@@ -1,0 +1,13 @@
+package com.heylocal.traveler.code.mapstruct.type;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface LocalDateMapper {
+  LocalDateMapper INSTANCE = Mappers.getMapper(LocalDateMapper.class);
+
+  @Mapping(target = "date", source = "localDate", dateFormat = "yyyy/MM/dd")
+  LocalDateDto toDto(LocalDateEntity entity);
+}

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/update/EntityUpdateMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/update/EntityUpdateMapper.java
@@ -1,0 +1,17 @@
+package com.heylocal.traveler.code.mapstruct.update;
+
+import com.heylocal.traveler.code.mapstruct.dependent.DependentOtherDto;
+import com.heylocal.traveler.code.mapstruct.dependent.DependentOtherEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface EntityUpdateMapper {
+  EntityUpdateMapper INSTANCE = Mappers.getMapper(EntityUpdateMapper.class);
+
+  @Mapping(target = "entity", source = "dto.entityDto")
+  @Mapping(target = "otherEntityList", source = "dto.otherEntityDtoList")
+  void updateEntity(DependentOtherDto dto, @MappingTarget DependentOtherEntity oldEntity);
+}

--- a/src/test/java/com/heylocal/traveler/controller/TravelOnsControllerTest.java
+++ b/src/test/java/com/heylocal/traveler/controller/TravelOnsControllerTest.java
@@ -9,7 +9,6 @@ import com.heylocal.traveler.domain.travelon.list.DrinkType;
 import com.heylocal.traveler.domain.travelon.list.FoodType;
 import com.heylocal.traveler.domain.travelon.list.MemberType;
 import com.heylocal.traveler.dto.LoginUser;
-import com.heylocal.traveler.dto.OpinionDto;
 import com.heylocal.traveler.exception.BadRequestException;
 import com.heylocal.traveler.exception.ForbiddenException;
 import com.heylocal.traveler.exception.NotFoundException;

--- a/src/test/java/com/heylocal/traveler/repository/OpinionRepositoryTest.java
+++ b/src/test/java/com/heylocal/traveler/repository/OpinionRepositoryTest.java
@@ -144,7 +144,7 @@ class OpinionRepositoryTest {
         .costPerformance(EvaluationDegree.GOOD)
         .build();
 
-    opinion.registerTravelOn(travelOn);
+    opinion.setTravelOn(travelOn);
 
     return opinion;
   }

--- a/src/test/java/com/heylocal/traveler/repository/TravelOnRepositoryTest.java
+++ b/src/test/java/com/heylocal/traveler/repository/TravelOnRepositoryTest.java
@@ -744,7 +744,7 @@ class TravelOnRepositoryTest {
         .build();
 
     em.persist(opinion);
-    opinion.registerTravelOn(travelOn);
+    opinion.setTravelOn(travelOn);
 
     return opinion;
   }

--- a/src/test/java/com/heylocal/traveler/service/OpinionServiceTest.java
+++ b/src/test/java/com/heylocal/traveler/service/OpinionServiceTest.java
@@ -12,7 +12,6 @@ import com.heylocal.traveler.domain.travelon.opinion.Opinion;
 import com.heylocal.traveler.domain.user.User;
 import com.heylocal.traveler.domain.user.UserRole;
 import com.heylocal.traveler.dto.LoginUser;
-import com.heylocal.traveler.dto.OpinionDto;
 import com.heylocal.traveler.exception.BadRequestException;
 import com.heylocal.traveler.exception.ForbiddenException;
 import com.heylocal.traveler.exception.NotFoundException;
@@ -31,8 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.heylocal.traveler.dto.OpinionDto.*;
 import static com.heylocal.traveler.dto.OpinionDto.OpinionRequest;
+import static com.heylocal.traveler.dto.OpinionDto.OpinionResponse;
 import static com.heylocal.traveler.dto.PlaceDto.PlaceRequest;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.AdditionalMatchers.not;


### PR DESCRIPTION
## Changes
- 기존 `DTO` 클래스들에 작성되어 있던 매핑 로직을 모두 제거함.
  - `엔티티를 매개변수로 받는 DTO 생성자` 제거
  - `toEntity(..) 메서드` 제거
- 필요한 매핑 로직을 모두 MapStruct 으로 구현하여 Mapping Interface 를 추가함.
- 기존 비즈니스 로직에 사용된 매핑 로직을 모두 MapStruct Mapping Interface 로 변경함.