### PR TITLE
[S3T-515] 플랜 장소 목록 응답 시 itemIndex로 정렬

### DIFF
--- a/src/main/java/com/heylocal/traveler/domain/plan/DaySchedule.java
+++ b/src/main/java/com/heylocal/traveler/domain/plan/DaySchedule.java
@@ -33,6 +33,7 @@ public class DaySchedule extends BaseTimeEntity {
   //양방향 설정
 
   @Builder.Default
+  @OrderBy(value = "itemIndex ASC")
   @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL)
   private List<PlaceItem> placeItemList = new ArrayList<>();
 


### PR DESCRIPTION
## Changes

- 플랜의 장소 목록 조회 API에서 장소 목록이 정렬되지 않은 순서로 응답되었음
- 엔티티에서 `@OrderBy` 추가하여 정렬