### PR TITLE
[S3T-517] 여행 On 수정 API 요청 시 HTTP 500이 반환되는 문제 해결

### DIFF
--- a/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
@@ -1,7 +1,7 @@
 package com.heylocal.traveler.mapper;
 
 import com.heylocal.traveler.domain.Region;
-import com.heylocal.traveler.domain.travelon.TravelOn;
+import com.heylocal.traveler.domain.travelon.*;
 import com.heylocal.traveler.domain.travelon.list.AccommodationType;
 import com.heylocal.traveler.domain.travelon.list.DrinkType;
 import com.heylocal.traveler.domain.travelon.list.FoodType;
@@ -98,6 +98,13 @@ public interface TravelOnMapper {
   @AfterMapping
   default void updateEntityTravelTypeGroup(TravelOnRequest travelOnRequest, @MappingTarget TravelOn travelOn) {
     TravelTypeGroupRequest travelTypeGroupRequest = travelOnRequest.getTravelTypeGroup();
-    TravelTypeGroupMapper.INSTANCE.toEntity(travelTypeGroupRequest, travelOn);
+    PlaceTasteType placeTasteType = travelTypeGroupRequest.getPlaceTasteType();
+    ActivityTasteType activityTasteType = travelTypeGroupRequest.getActivityTasteType();
+    SnsTasteType snsTasteType = travelTypeGroupRequest.getSnsTasteType();
+
+    TravelTypeGroup travelTypeGroup = travelOn.getTravelTypeGroup();
+    travelTypeGroup.setPlaceTasteType(placeTasteType);
+    travelTypeGroup.setActivityTasteType(activityTasteType);
+    travelTypeGroup.setSnsTasteType(snsTasteType);
   }
 }


### PR DESCRIPTION
## Changes

- 자세한 내용은 Jira `S3T-517` 참고!
- `TravelOnMapper::updateTravelOn` 이후 `@AfterMapping`으로 실행되는 `updateEntityTravelTypeGroup`에서, 기존에는 여행 On ID가 같은 새 `TravelTypeGroup`의 insert 쿼리가 발생하면서 Unique key 제약 조건을 위배하였고 `SQLException`이 발생함
- 새 `TravelTypeGroup`을 insert하지 않고 기존 Row에 update되도록 수정

## Note

- 더 나은 해결 방법이 있거나,
- 수정된 코드가 기존 코드에서 의도한 바에 반하는 부분이 있다면 리뷰 바랍니다!