### PR TITLE
[S3T-516] 플랜이 여행 시작 날짜, 종료 날짜, 지역 정보를 직접 갖도록 수정

### DIFF
--- a/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
+++ b/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
@@ -1,12 +1,14 @@
 package com.heylocal.traveler.domain.plan;
 
 import com.heylocal.traveler.domain.BaseTimeEntity;
+import com.heylocal.traveler.domain.Region;
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.user.User;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +36,15 @@ public class Plan extends BaseTimeEntity {
 
   @ManyToOne(optional = false)
   private User user;
+
+  @ManyToOne(optional = false)
+  private Region region;
+
+  @Column(nullable = false)
+  private LocalDate travelStartDate;
+
+  @Column(nullable = false)
+  private LocalDate travelEndDate;
 
   //양방향 설정
 

--- a/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
+++ b/src/main/java/com/heylocal/traveler/domain/plan/Plan.java
@@ -70,4 +70,12 @@ public class Plan extends BaseTimeEntity {
   public void updateTitle(String title) {
     this.title = title;
   }
+
+  public void updateTravelStartDate(LocalDate date) {
+    this.travelStartDate = date;
+  }
+
+  public void updateTravelEndDate(LocalDate date) {
+    this.travelEndDate = date;
+  }
 }

--- a/src/main/java/com/heylocal/traveler/mapper/PlanMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/PlanMapper.java
@@ -14,11 +14,11 @@ import static com.heylocal.traveler.dto.PlanDto.PlanResponse;
 public interface PlanMapper {
   PlanMapper INSTANCE = Mappers.getMapper(PlanMapper.class);
 
-  @Mapping(target = "regionId", source = "plan.travelOn.region.id")
-  @Mapping(target = "regionState", source = "plan.travelOn.region.state")
-  @Mapping(target = "regionCity", source = "plan.travelOn.region.city")
-  @Mapping(target = "startDate", source = "plan.travelOn.travelStartDate")
-  @Mapping(target = "endDate", source = "plan.travelOn.travelEndDate")
+  @Mapping(target = "regionId", source = "plan.region.id")
+  @Mapping(target = "regionState", source = "plan.region.state")
+  @Mapping(target = "regionCity", source = "plan.region.city")
+  @Mapping(target = "startDate", source = "plan.travelStartDate")
+  @Mapping(target = "endDate", source = "plan.travelEndDate")
   PlanResponse toPlanResponseDto(Plan plan);
 
   @Mapping(target = "date", source = "daySchedule.dateTime")

--- a/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/TravelOnMapper.java
@@ -98,11 +98,17 @@ public interface TravelOnMapper {
   @AfterMapping
   default void updateEntityTravelTypeGroup(TravelOnRequest travelOnRequest, @MappingTarget TravelOn travelOn) {
     TravelTypeGroupRequest travelTypeGroupRequest = travelOnRequest.getTravelTypeGroup();
+    TravelTypeGroup travelTypeGroup = travelOn.getTravelTypeGroup();
+
+    if (travelTypeGroup == null) {
+      TravelTypeGroupMapper.INSTANCE.toEntity(travelTypeGroupRequest, travelOn);
+      return;
+    }
+
     PlaceTasteType placeTasteType = travelTypeGroupRequest.getPlaceTasteType();
     ActivityTasteType activityTasteType = travelTypeGroupRequest.getActivityTasteType();
     SnsTasteType snsTasteType = travelTypeGroupRequest.getSnsTasteType();
 
-    TravelTypeGroup travelTypeGroup = travelOn.getTravelTypeGroup();
     travelTypeGroup.setPlaceTasteType(placeTasteType);
     travelTypeGroup.setActivityTasteType(activityTasteType);
     travelTypeGroup.setSnsTasteType(snsTasteType);

--- a/src/main/java/com/heylocal/traveler/service/PlanService.java
+++ b/src/main/java/com/heylocal/traveler/service/PlanService.java
@@ -135,6 +135,9 @@ public class PlanService {
 				.title(planTitle)
 				.travelOn(travelOn)
 				.user(travelOn.getAuthor())
+				.region(travelOn.getRegion())
+				.travelStartDate(travelOn.getTravelStartDate())
+				.travelEndDate(travelOn.getTravelEndDate())
 				.build();
 		daySchedules.forEach(plan::addDaySchedule); // DaySchedule 추가
 		planRepository.save(plan); // 저장

--- a/src/main/java/com/heylocal/traveler/service/TravelOnService.java
+++ b/src/main/java/com/heylocal/traveler/service/TravelOnService.java
@@ -1,6 +1,7 @@
 package com.heylocal.traveler.service;
 
 import com.heylocal.traveler.domain.Region;
+import com.heylocal.traveler.domain.plan.Plan;
 import com.heylocal.traveler.domain.travelon.TravelOn;
 import com.heylocal.traveler.domain.user.User;
 import com.heylocal.traveler.dto.LoginUser;
@@ -119,6 +120,13 @@ public class TravelOnService {
 
     //여행On 업데이트
     TravelOnMapper.INSTANCE.updateTravelOn(request, originTravelOn);
+
+    //연관 플랜이 있는 경우 업데이트
+    Plan plan = originTravelOn.getPlan();
+    if (plan != null) {
+      plan.updateTravelStartDate(request.getTravelStartDate());
+      plan.updateTravelEndDate(request.getTravelEndDate());
+    }
   }
 
   /**

--- a/src/test/java/com/heylocal/traveler/repository/PlanRepositoryTest.java
+++ b/src/test/java/com/heylocal/traveler/repository/PlanRepositoryTest.java
@@ -137,6 +137,9 @@ class PlanRepositoryTest {
 				.title("TITLE")
 				.travelOn(travelOn)
 				.user(user)
+				.region(travelOn.getRegion())
+				.travelStartDate(travelOn.getTravelStartDate())
+				.travelEndDate(travelOn.getTravelEndDate())
 				.build();
 	}
 

--- a/src/test/java/com/heylocal/traveler/service/PlanServiceTest.java
+++ b/src/test/java/com/heylocal/traveler/service/PlanServiceTest.java
@@ -115,6 +115,9 @@ class PlanServiceTest {
 					.id(1L)
 					.user(user)
 					.travelOn(travelOn)
+					.region(travelOn.getRegion())
+					.travelStartDate(travelOn.getTravelStartDate())
+					.travelEndDate(travelOn.getTravelEndDate())
 					.build());
 		}
 


### PR DESCRIPTION
## Changes

- 여행 On이 삭제되고 플랜만 남은 경우에, 플랜의 여행 시작 날짜, 종료 날짜, 지역을 알 수 없기 때문에 이 정보들을 플랜 엔티티에 추가하였음
- 플랜 생성 시 위 정보들을 여행 On에서 복사
- 여행 On 수정 시 여행 시작 날짜, 종료 날짜 변경 사항을 플랜에도 반영 (지역은 수정 불가능한 정보이므로 논외)
- `PlanMapper` 수정
- 테스트 코드 수정
- PR #99 에서 발생한 테스트 실패 문제 해결
  - `TravelTypeGroup`이 없는 경우에는 Insert하도록 분기

## Note

- 잘 작동은 하지만, 같은 정보를 `TRAVEL_ON`과 `PLAN` 두 테이블에서 같이 관리하는 형태라 정합성 관점에서는 음...
