### PR TITLE
[S3T-529] 모든 지역 조회 로직 추가

### DIFF
--- a/src/main/java/com/heylocal/traveler/controller/RegionController.java
+++ b/src/main/java/com/heylocal/traveler/controller/RegionController.java
@@ -26,7 +26,11 @@ public class RegionController implements RegionsApi {
 	public List<RegionResponse> getRegions(String state) throws NotFoundException {
 		List<RegionResponse> response;
 
-		response = regionService.inquiryRegions(state);
+		if (state == null || state.isEmpty()) { //만약 state가 없다면
+			response = regionService.inquiryAllRegions();
+		} else { //만약 state가 있다면
+			response = regionService.inquiryRegions(state);
+		}
 
 		return response;
 	}

--- a/src/main/java/com/heylocal/traveler/controller/api/RegionsApi.java
+++ b/src/main/java/com/heylocal/traveler/controller/api/RegionsApi.java
@@ -24,6 +24,6 @@ public interface RegionsApi {
 	})
 	@GetMapping()
 	List<RegionResponse> getRegions(
-			@Parameter(in = ParameterIn.QUERY, description = "조회할 City의 State", required = true) String state
+			@Parameter(in = ParameterIn.QUERY, description = "조회할 City의 State\n\n만약 아무 값도 전달하지 않는다면, 모든 지역을 조회한다.", required = false) String state
 	) throws NotFoundException;
 }

--- a/src/main/java/com/heylocal/traveler/repository/RegionRepository.java
+++ b/src/main/java/com/heylocal/traveler/repository/RegionRepository.java
@@ -15,6 +15,24 @@ public class RegionRepository {
   private EntityManager em;
 
   /**
+   * <pre>
+   * 특별시, 광역시, 제주도, 그 외 시·군 을 조회하는 메서드
+   * </pre>
+   * @return
+   */
+  public List<Region> findAll() {
+    String jpql = "select r from Region r" +
+        " where (r.state not in ('서울특별시', '부산광역시', '대구광역시', '인천광역시', '광주광역시', '대전광역시', '울산광역시', '세종특별자치시', '제주특별자치도')" +
+          " and r.city not like '%구')" +
+        " or (r.state in ('서울특별시', '부산광역시', '대구광역시', '인천광역시', '광주광역시', '대전광역시', '울산광역시', '세종특별자치시', '제주특별자치도')" +
+          " and r.city is null)";
+
+    List<Region> result = em.createQuery(jpql, Region.class).getResultList();
+
+    return result;
+  }
+
+  /**
    * id 로 Region 엔티티를 조회하는 메서드
    * @param id
    * @return

--- a/src/main/java/com/heylocal/traveler/service/RegionService.java
+++ b/src/main/java/com/heylocal/traveler/service/RegionService.java
@@ -38,6 +38,19 @@ public class RegionService {
     }
     result = regionList.stream().map(RegionMapper.INSTANCE::toResponseDto).collect(Collectors.toList());
 
+    return result;
+  }
+
+  /**
+   * 모든 Region 조회
+   * @return
+   */
+  @Transactional(readOnly = true)
+  public List<RegionResponse> inquiryAllRegions() {
+    List<RegionResponse> result;
+    List<Region> regionList = regionRepository.findAll();
+
+    result = regionList.stream().map(RegionMapper.INSTANCE::toResponseDto).collect(Collectors.toList());
 
     return result;
   }

--- a/src/test/java/com/heylocal/traveler/code/mapstruct/update/EntityUpdateMapper.java
+++ b/src/test/java/com/heylocal/traveler/code/mapstruct/update/EntityUpdateMapper.java
@@ -11,6 +11,7 @@ import org.mapstruct.factory.Mappers;
 public interface EntityUpdateMapper {
   EntityUpdateMapper INSTANCE = Mappers.getMapper(EntityUpdateMapper.class);
 
+  @Mapping(target = "id", ignore = true)
   @Mapping(target = "entity", source = "dto.entityDto")
   @Mapping(target = "otherEntityList", source = "dto.otherEntityDtoList")
   void updateEntity(DependentOtherDto dto, @MappingTarget DependentOtherEntity oldEntity);

--- a/src/test/java/com/heylocal/traveler/controller/RegionControllerTest.java
+++ b/src/test/java/com/heylocal/traveler/controller/RegionControllerTest.java
@@ -13,7 +13,9 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
 
 class RegionControllerTest {
   @Mock
@@ -41,8 +43,14 @@ class RegionControllerTest {
 
     //THEN
     assertAll(
-        //성공 케이스 - 1 - 정상 state 으로 요청 시
+        //성공 케이스 - 1 - 정상 state 로 요청 시
         () -> assertDoesNotThrow(() -> regionController.getRegions(existState)),
+        //성공 케이스 - 2 - 빈 state 로 요청 시
+        () -> {
+          regionController.getRegions(null);
+          regionController.getRegions("");
+          then(regionService).should(times(2)).inquiryAllRegions();
+        },
         //실패 케이스 - 1 - 존재하지 않는 state 으로 요청 시
         () -> assertThrows(NotFoundException.class, () -> regionController.getRegions(notExistState))
     );


### PR DESCRIPTION
## Changes
- 기존의 지역 조회 API 호출 시 파라미터를 전달하지 않을 경우, 모든 지역을 조회하여 응답하도록 수정함.
  - 이때 응답하는 지역들은 모두 `특별시`·`광역시`·`제주도`·`시·군` 임.
- 관련 테스트 코드 추가