### PR TITLE
[S3T-581] 개발 Local용 AWS S3 정보 properties 파일 추가 및 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ Temporary Items
 /src/main/resources/production-db.properties
 /src/main/resources/aws-key-stage.properties
 /src/main/resources/aws-key-production.properties
+/src/main/resources/aws-key-local.properties

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -5,6 +5,9 @@
 # description    : 개발용 로컬 설정 properties 파일
 # ====================================================
 
+# AWS 설정 정보 import
+spring.config.import=aws-local.properties
+
 # JPA
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create

--- a/src/main/resources/aws-local.properties
+++ b/src/main/resources/aws-local.properties
@@ -1,0 +1,21 @@
+# ====================== Header ======================
+# fileName       : aws-local.properties
+# author         : 우태균
+# date           : 2022/10/16
+# description    : AWS 설정 properties 파일
+# ====================================================
+
+# AWS 인증 정보 import
+spring.config.import=aws-key-local.properties
+
+# AWS S3 Service bucket
+cloud.aws.s3.bucket=heylocal
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.region.auto=false
+cloud.aws.stack.auto=false
+
+# AWS S3 Bucket URL
+cloud.aws.s3.bucket.url=https://s3.ap-northeast-2.amazonaws.com/heylocal-production
+
+# AWS \uB97C \uB85C\uCEEC\uC5D0\uC11C \uB3CC\uB9B4\uB54C \uB728\uB294 \uC5D0\uB7EC \uC81C\uAC70
+logging.level.com.amazonaws.util.EC2MetadataUtils=ERROR


### PR DESCRIPTION
## Changes
- 로컬 환경에서 App 구동 시, AWS 라이브러리 관련 오류가 발생하는 문제 해결
  - 원인: properties 파일을 분리하는 과정에서 필요한 설정 정보가 로컬 환경에 포함되지 않음