### PR TITLE
[S3T-540] PlaceItemMapper::toPlaceItemEntity에서 opinion에 대한 매핑을 ignore

### DIFF
--- a/src/main/java/com/heylocal/traveler/mapper/PlaceItemMapper.java
+++ b/src/main/java/com/heylocal/traveler/mapper/PlaceItemMapper.java
@@ -26,6 +26,7 @@ public interface PlaceItemMapper {
   @Mapping(target = "type", expression = "java(PlaceItemType.ORIGINAL)")
   @Mapping(target = "place", expression = "java(PlaceMapper.INSTANCE.toEntity(placeItemRequest))")
   @Mapping(target = "originalPlaceId", ignore = true)
+  @Mapping(target = "opinion", ignore = true)
   PlaceItem toPlaceItemEntity(PlaceItemDto.PlaceItemRequest placeItemRequest);
 
   @Mapping(target = "name", source = "placeItem.place.name")


### PR DESCRIPTION
## Changes

- DTO에서 Entity로 매핑 시, `opinion` 필드 값에 대해 ignore
  - 답변 채택이 아니라 장소를 직접 검색해 추가하는 경우 답변과는 연관이 없고, DTO에도 답변에 대한 필드가 존재하지 않음
  - 그래서 `null`로 설정되어야 함